### PR TITLE
Add option to explicitly get Kinesis credentials from IAM role

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -42,6 +42,7 @@ module.exports = function getLogger(pkg, env, serializers) {
       secretAccessKey: env['AWS_ACCESS_KEY_SECRET'],
       streamName: env['LOG_TO_KINESIS'],
       region: env['AWS_KINESIS_REGION'] || env['AWS_REGION'],
+      getCredentialsFromIAMRole: env['AWS_GET_CREDENTIALS_FROM_IAM_ROLE'],
       httpOptions: {
         agent: keep_alive_agent('aws-kinesis')
       },


### PR DESCRIPTION
This would allow us to use this feature: https://github.com/auth0/kinesis-writable/commit/a1b45ce16d086e1d75d5891fc9faca924360cdcc