### PR TITLE
Add the ability to set default tags that will be used in every metrics-related call

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -3,6 +3,7 @@ module.exports = function(pkg, env) {
     return require('./stubs').metrics;
   }
 
+  var _ = require('lodash');
   var utils = require('./utils');
 
   process.env.DATADOG_API_KEY = env.METRICS_API_KEY;
@@ -26,25 +27,36 @@ module.exports = function(pkg, env) {
     }, env.COLLECT_RESOURCE_USAGE_INTERVAL || 5000);
   }
 
-  var gauge = function(name, value, tags) {
-    return metrics.gauge(name, value, utils.processTags(tags));
+  var obj = {
+    isActive: true,
+    __defaultTags: []
   };
-  var increment = function(name, value, tags) {
+
+  var getTags = function(tags) {
+    return _.extend(obj.__defaultTags || [], utils.processTags(tags));
+  };
+
+  obj.setDefaultTags = function(tags) {
+    obj.__defaultTags = utils.processTags(tags);
+  };
+
+  obj.gauge = function(name, value, tags) {
+    return metrics.gauge(name, value, getTags(tags));
+  };
+
+  obj.increment = function(name, value, tags) {
     if (Array.isArray(value)) {
       tags = value;
       value = 1;
     }
-    return metrics.increment(name, value, utils.processTags(tags));
-  };
-  var histogram = function(name, value, tags) {
-    return metrics.histogram(name, value, utils.processTags(tags));
+    return metrics.increment(name, value, getTags(tags));
   };
 
-  return {
-    isActive: true,
-    gauge: gauge,
-    increment: increment,
-    histogram: histogram,
-    flush: metrics.flush
+  obj.histogram = function(name, value, tags) {
+    return metrics.histogram(name, value, getTags(tags));
   };
+
+  obj.flush = metrics.flush;
+
+  return obj;
 };

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -31,7 +31,8 @@ var emptyMetrics = {
   gauge: noop,
   increment: noop,
   histogram: noop,
-  flush: noop
+  flush: noop,
+  setDefaultTags: noop
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bunyan": "^1.7.1",
     "bunyan-sqs": "0.0.3",
     "datadog-metrics": "^0.3.0",
+    "lodash": "^4.13.1",
     "pidusage": "^1.0.1",
     "raven": "^0.10.0"
   },

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -45,9 +45,18 @@ describe('metrics', function() {
   });
 
   it('should run flush without throwing', function(done) {
-    assert.doesNotThrow(function() {
-      metrics.flush();
-    }, TypeError);
+    assert.doesNotThrow(metrics.flush, TypeError);
+    done();
+  });
+
+  it('should run setDefaultTags without throwing', function(done) {
+    assert.doesNotThrow(metrics.setDefaultTags, TypeError);
+    done();
+  });
+
+  it('should set default tags', function(done) {
+    metrics.setDefaultTags({'color': 'red', 'region': 'west'});
+    assert.deepEqual(metrics.__defaultTags, ['color:red', 'region:west']);
     done();
   });
 

--- a/test/stubs.test.js
+++ b/test/stubs.test.js
@@ -15,16 +15,12 @@ describe('stubs', function() {
     });
 
     it('should run captureException without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        errorReporter.captureException();
-      }, TypeError);
+      assert.doesNotThrow(errorReporter.captureException, TypeError);
       done();
     });
 
     it('should run patchGlobal without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        errorReporter.patchGlobal();
-      }, TypeError);
+      assert.doesNotThrow(errorReporter.patchGlobal, TypeError);
       done();
     });
 
@@ -53,30 +49,27 @@ describe('stubs', function() {
     });
 
     it('should run gauge without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        metrics.gauge();
-      }, TypeError);
+      assert.doesNotThrow(metrics.gauge, TypeError);
       done();
     });
 
     it('should run increment without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        metrics.increment();
-      }, TypeError);
+      assert.doesNotThrow(metrics.increment, TypeError);
       done();
     });
 
     it('should run histogram without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        metrics.histogram();
-      }, TypeError);
+      assert.doesNotThrow(metrics.histogram, TypeError);
       done();
     });
 
     it('should run flush without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        metrics.flush();
-      }, TypeError);
+      assert.doesNotThrow(metrics.flush, TypeError);
+      done();
+    });
+
+    it('should run setDefaultTags without throwing', function(done) {
+      assert.doesNotThrow(metrics.setDefaultTags, TypeError);
       done();
     });
 
@@ -85,44 +78,32 @@ describe('stubs', function() {
   describe('logger', function() {
 
     it('should run trace without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.trace();
-      }, TypeError);
+      assert.doesNotThrow(logger.trace, TypeError);
       done();
     });
 
     it('should run debug without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.debug();
-      }, TypeError);
+      assert.doesNotThrow(logger.debug, TypeError);
       done();
     });
 
     it('should run info without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.info();
-      }, TypeError);
+      assert.doesNotThrow(logger.info, TypeError);
       done();
     });
 
     it('should run warn without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.warn();
-      }, TypeError);
+      assert.doesNotThrow(logger.warn, TypeError);
       done();
     });
 
     it('should run error without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.error();
-      }, TypeError);
+      assert.doesNotThrow(logger.error, TypeError);
       done();
     });
 
     it('should run fatal without throwing', function(done) {
-      assert.doesNotThrow(function() {
-        logger.fatal();
-      }, TypeError);
+      assert.doesNotThrow(logger.fatal, TypeError);
       done();
     });
 


### PR DESCRIPTION
This could be used to set information about the environment; e.g. the AWS region if using AWS.

```js
var pkg = require('./package.json');
var env = require('./lib/env');
var agent = require('auth0-instrumentation');
agent.init(pkg, env);
var metrics = agent.metrics;

// we do this once
metrics.setDefaultTags({
  'region': 'us-west-1',
  'instance-type': 'whatever'
});

// and then every call gets its own tags + the default ones
// here we will send ['path:foo', 'region:us-west-1', 'instance-type:whatever']
metrics.increment('requests.processed', { path: 'foo' });