### PR TITLE
Unify error pipeline

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,80 +1,89 @@
+const SentryStream = require('bunyan-sentry-stream').SentryStream;
+
 module.exports = function getLogger(pkg, env, serializers) {
-	var bunyan = require('bunyan');
-	var ProcessInfo = require('auth0-common-logging').ProcessInfo;
+  var bunyan = require('bunyan');
+  var ProcessInfo = require('auth0-common-logging').ProcessInfo;
 
-	if (!serializers) {
-		serializers = require('auth0-common-logging').Serializers;
-	}
+  if (!serializers) {
+    serializers = require('auth0-common-logging').Serializers;
+  }
 
-	var bunyan_streams = [{
-		level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
-		stream: process.stdout
-	}];
+  var bunyan_streams = [{
+    level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
+    stream: process.stdout
+  }];
 
-	if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
-		var HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
-		bunyan_streams.push({
-			name: 'web-url',
-			stream: new HttpWritableStream(env.LOG_TO_WEB_URL),
-			level: env.LOG_TO_WEB_LEVEL || 'error'
-		});
-	}
+  if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
+    var HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
+    bunyan_streams.push({
+      name: 'web-url',
+      stream: new HttpWritableStream(env.LOG_TO_WEB_URL),
+      level: env.LOG_TO_WEB_LEVEL || 'error'
+    });
+  }
 
-	if (env.LOG_TO_KINESIS || env.KINESIS_POOL) {
-		var keepAliveAgent = require('./keep_alive_agent')(env);
-		var KinesisWritable = require('aws-kinesis-writable');
-		var KinesisStreamPool = require('aws-kinesis-writable').pool;
-		var utils = require('./utils');
+  if (env.LOG_TO_KINESIS || env.KINESIS_POOL) {
+    var keepAliveAgent = require('./keep_alive_agent')(env);
+    var KinesisWritable = require('aws-kinesis-writable');
+    var KinesisStreamPool = require('aws-kinesis-writable').pool;
+    var utils = require('./utils');
 
-		var stream;
-		if (env.KINESIS_POOL) {
-			// pool for failover
-			var kinesisStreams = env.KINESIS_POOL.map(function(config) {
-				// prioritize pool config over global but if not in pool, take global (e.g. AWS_REGION)
-				var kinesisInstance = new KinesisWritable(utils.buildKinesisOptions(Object.assign({}, env, config), keepAliveAgent));
-				if (config.IS_PRIMARY) {
-					kinesisInstance.primary = true;
-				}
-				return kinesisInstance;
-			});
-			stream = new KinesisStreamPool({
-				streams: kinesisStreams
-			});
-		} else {
-			// single stream, no failover
-			stream = new KinesisWritable(utils.buildKinesisOptions(env, keepAliveAgent));
-		}
+    var stream;
+    if (env.KINESIS_POOL) {
+      // pool for failover
+      var kinesisStreams = env.KINESIS_POOL.map(function(config) {
+        // prioritize pool config over global but if not in pool, take global (e.g. AWS_REGION)
+        var kinesisInstance = new KinesisWritable(utils.buildKinesisOptions(Object.assign({}, env, config), keepAliveAgent));
+        if (config.IS_PRIMARY) {
+          kinesisInstance.primary = true;
+        }
+        return kinesisInstance;
+      });
+      stream = new KinesisStreamPool({
+        streams: kinesisStreams
+      });
+    } else {
+      // single stream, no failover
+      stream = new KinesisWritable(utils.buildKinesisOptions(env, keepAliveAgent));
+    }
 
-		var streamErrorHandler = function(err) {
-			console.error(JSON.stringify({
-				message: err.message,
-				records: err.records,
-				stack: err.stack
-			}));
-		};
-		stream.on('error', streamErrorHandler);
-		stream.on('poolFailure', streamErrorHandler);
+    var streamErrorHandler = function(err) {
+      console.error(JSON.stringify({
+        message: err.message,
+        records: err.records,
+        stack: err.stack
+      }));
+    };
+    stream.on('error', streamErrorHandler);
+    stream.on('poolFailure', streamErrorHandler);
 
-		bunyan_streams.push({
-			name: 'kinesis',
-			stream: stream,
-			level: env.LOG_TO_KINESIS_LEVEL,
-			type: env.LOG_TO_KINESIS_LOG_TYPE
-		});
+    bunyan_streams.push({
+      name: 'kinesis',
+      stream: stream,
+      level: env.LOG_TO_KINESIS_LEVEL,
+      type: env.LOG_TO_KINESIS_LOG_TYPE
+    });
 
-	}
+  }
 
-	var logger = bunyan.createLogger({
-		name: pkg.name,
-		process: ProcessInfo && !env.IGNORE_PROCESS_INFO && ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined,
-		region: env.AWS_REGION,
-		streams: bunyan_streams,
-		serializers: serializers
-	});
+  bunyan_streams.push({
+    name: 'sentry',
+    stream: new SentryStream(require('./error_reporter')(pkg, env)),
+    level: 'error',
+    type: 'raw'
+  });
 
-	logger.on('error', function(err, stream) {
-		console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
-	});
+  var logger = bunyan.createLogger({
+    name: pkg.name,
+    process: ProcessInfo && !env.IGNORE_PROCESS_INFO && ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined,
+    region: env.AWS_REGION,
+    streams: bunyan_streams,
+    serializers: serializers
+  });
 
-	return logger;
+  logger.on('error', function(err, stream) {
+    console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
+  });
+
+  return logger;
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,80 +1,80 @@
 module.exports = function getLogger(pkg, env, serializers) {
-  var bunyan = require('bunyan');
-  var ProcessInfo = require('auth0-common-logging').ProcessInfo;
+	var bunyan = require('bunyan');
+	var ProcessInfo = require('auth0-common-logging').ProcessInfo;
 
-  if (!serializers) {
-    serializers = require('auth0-common-logging').Serializers;
-  }
+	if (!serializers) {
+		serializers = require('auth0-common-logging').Serializers;
+	}
 
-  var bunyan_streams = [{
-    level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
-    stream: process.stdout
-  }];
+	var bunyan_streams = [{
+		level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
+		stream: process.stdout
+	}];
 
-  if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
-    var HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
-    bunyan_streams.push({
-      name: 'web-url',
-      stream: new HttpWritableStream(env.LOG_TO_WEB_URL),
-      level: env.LOG_TO_WEB_LEVEL || 'error'
-    });
-  }
+	if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
+		var HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
+		bunyan_streams.push({
+			name: 'web-url',
+			stream: new HttpWritableStream(env.LOG_TO_WEB_URL),
+			level: env.LOG_TO_WEB_LEVEL || 'error'
+		});
+	}
 
-  if (env.LOG_TO_KINESIS || env.KINESIS_POOL) {
-    var keepAliveAgent = require('./keep_alive_agent')(env);
-    var KinesisWritable = require('aws-kinesis-writable');
-    var KinesisStreamPool = require('aws-kinesis-writable').pool;
-    var utils = require('./utils');
+	if (env.LOG_TO_KINESIS || env.KINESIS_POOL) {
+		var keepAliveAgent = require('./keep_alive_agent')(env);
+		var KinesisWritable = require('aws-kinesis-writable');
+		var KinesisStreamPool = require('aws-kinesis-writable').pool;
+		var utils = require('./utils');
 
-    var stream;
-    if (env.KINESIS_POOL) {
-      // pool for failover
-      var kinesisStreams = env.KINESIS_POOL.map(function(config) {
-        // prioritize pool config over global but if not in pool, take global (e.g. AWS_REGION)
-        var kinesisInstance = new KinesisWritable(utils.buildKinesisOptions(Object.assign({}, env, config), keepAliveAgent));
-        if (config.IS_PRIMARY) {
-          kinesisInstance.primary = true;
-        }
-        return kinesisInstance;
-      });
-      stream = new KinesisStreamPool({
-        streams: kinesisStreams
-      });
-    } else {
-      // single stream, no failover
-      stream = new KinesisWritable(utils.buildKinesisOptions(env, keepAliveAgent));
-    }
+		var stream;
+		if (env.KINESIS_POOL) {
+			// pool for failover
+			var kinesisStreams = env.KINESIS_POOL.map(function(config) {
+				// prioritize pool config over global but if not in pool, take global (e.g. AWS_REGION)
+				var kinesisInstance = new KinesisWritable(utils.buildKinesisOptions(Object.assign({}, env, config), keepAliveAgent));
+				if (config.IS_PRIMARY) {
+					kinesisInstance.primary = true;
+				}
+				return kinesisInstance;
+			});
+			stream = new KinesisStreamPool({
+				streams: kinesisStreams
+			});
+		} else {
+			// single stream, no failover
+			stream = new KinesisWritable(utils.buildKinesisOptions(env, keepAliveAgent));
+		}
 
-    var streamErrorHandler = function(err) {
-      console.error(JSON.stringify({
-        message: err.message,
-        records: err.records,
-        stack: err.stack
-      }));
-    };
-    stream.on('error', streamErrorHandler);
-    stream.on('poolFailure', streamErrorHandler);
+		var streamErrorHandler = function(err) {
+			console.error(JSON.stringify({
+				message: err.message,
+				records: err.records,
+				stack: err.stack
+			}));
+		};
+		stream.on('error', streamErrorHandler);
+		stream.on('poolFailure', streamErrorHandler);
 
-    bunyan_streams.push({
-      name: 'kinesis',
-      stream: stream,
-      level: env.LOG_TO_KINESIS_LEVEL,
-      type: env.LOG_TO_KINESIS_LOG_TYPE
-    });
+		bunyan_streams.push({
+			name: 'kinesis',
+			stream: stream,
+			level: env.LOG_TO_KINESIS_LEVEL,
+			type: env.LOG_TO_KINESIS_LOG_TYPE
+		});
 
-  }
+	}
 
-  var logger = bunyan.createLogger({
-    name: pkg.name,
-    process: ProcessInfo && !env.IGNORE_PROCESS_INFO && ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined,
-    region: env.AWS_REGION,
-    streams: bunyan_streams,
-    serializers: serializers
-  });
+	var logger = bunyan.createLogger({
+		name: pkg.name,
+		process: ProcessInfo && !env.IGNORE_PROCESS_INFO && ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined,
+		region: env.AWS_REGION,
+		streams: bunyan_streams,
+		serializers: serializers
+	});
 
-  logger.on('error', function(err, stream) {
-    console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
-  });
+	logger.on('error', function(err, stream) {
+		console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
+	});
 
-  return logger;
+	return logger;
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,7 +11,7 @@ module.exports = function getLogger(pkg, env, serializers) {
     stream: process.stdout
   }];
 
-  if(process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL){
+  if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
     var HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
     bunyan_streams.push({
       name: 'web-url',

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -14,6 +14,7 @@ const emptyLogger = {
 const emptyErrorReporter = {
   isActive: false,
   captureException: spy(),
+  captureMessage: spy(),
   patchGlobal: spy(),
   hapi: {
     plugin: {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "mocha": "^2.4.5",
-    "nsp": "^2.5.0"
+    "nsp": "^2.5.0",
+    "mockuire": "^0.1.0",
+    "sinon": "^1.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "aws-kinesis-writable": "~2.0.0",
     "blocked": "^1.2.1",
     "bunyan": "^1.8.1",
+    "bunyan-sentry-stream": "^1.0.2",
     "datadog-metrics": "^0.3.0",
     "pidusage": "^1.0.1",
     "raven": "^0.10.0",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,0 @@
-var env = {'NODE_ENV': 'production', 'IGNORE_PROCESS_INFO': true};
-var pkg = {'name': 'foo'};
-var agent = require('./index');
-
-agent.init(pkg, env);
-agent.logger.error("WHOA");

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const spy = require('sinon').spy;
+const $require = require('mockuire')(module);
+
+const spyException = spy();
+const spyMessage = spy();
+const logger = $require('../lib/logger', {
+  './error_reporter': function() {
+    return {
+      captureException: spyException,
+      captureMessage: spyMessage
+    }
+  }
+})({ name: 'test' }, { LOG_LEVEL: 'fatal' });
+
+describe('logger', function() {
+  beforeEach(function() {
+    spyException.reset();
+    spyMessage.reset();
+  });
+
+  describe('SentryStream', function() {
+    it('should call captureException on error when level is error', function() {
+      logger.error(new Error('test'));
+      assert(spyException.calledOnce);
+      assert(spyMessage.calledOnce === false);
+    });
+
+    it('should call captureMessage on string when level is error', function() {
+      logger.error('test');
+      assert(spyException.calledOnce === false);
+      assert(spyMessage.calledOnce);
+    });
+  });
+});

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,37 +1,26 @@
 'use strict';
 
 const assert = require('assert');
-const spy = require('sinon').spy;
-const $require = require('mockuire')(module);
-
-const spyException = spy();
-const spyMessage = spy();
-const logger = $require('../lib/logger', {
-  './error_reporter': function() {
-    return {
-      captureException: spyException,
-      captureMessage: spyMessage
-    }
-  }
-})({ name: 'test' }, { LOG_LEVEL: 'fatal' });
+const sentry = require('../lib/error_reporter')({}, {});
+const logger = require('../lib/logger')({ name: 'test' }, { LOG_LEVEL: 'fatal' });
 
 describe('logger', function() {
   beforeEach(function() {
-    spyException.reset();
-    spyMessage.reset();
+    sentry.captureException.reset();
+    sentry.captureMessage.reset();
   });
 
   describe('SentryStream', function() {
     it('should call captureException on error when level is error', function() {
       logger.error(new Error('test'));
-      assert(spyException.calledOnce);
-      assert(spyMessage.calledOnce === false);
+      assert(sentry.captureException.calledOnce);
+      assert(sentry.captureMessage.calledOnce === false);
     });
 
     it('should call captureMessage on string when level is error', function() {
       logger.error('test');
-      assert(spyException.calledOnce === false);
-      assert(spyMessage.calledOnce);
+      assert(sentry.captureException.calledOnce === false);
+      assert(sentry.captureMessage.calledOnce);
     });
   });
 });


### PR DESCRIPTION
Send any level `error` or above to our `error_reporter` (sentry).

Underlying lib will extract the additional `error` information and add it to the `extra` section specified for sentry.