### PR TITLE
Use spies

### DIFF
--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -1,19 +1,20 @@
-var noop = function() {};
-var emptyMiddleware = function (a, b, next) { next(); };
+const spy = require('sinon').spy;
 
-var emptyLogger = {
-  trace: noop,
-  debug: noop,
-  info: noop,
-  warn: noop,
-  error: noop,
-  fatal: noop
+const emptyMiddleware = function (a, b, next) { next(); };
+
+const emptyLogger = {
+  trace: spy(),
+  debug: spy(),
+  info: spy(),
+  warn: spy(),
+  error: spy(),
+  fatal: spy()
 };
 
-var emptyErrorReporter = {
+const emptyErrorReporter = {
   isActive: false,
-  captureException: noop,
-  patchGlobal: noop,
+  captureException: spy(),
+  patchGlobal: spy(),
   hapi: {
     plugin: {
       register: emptyMiddleware
@@ -26,13 +27,13 @@ var emptyErrorReporter = {
 };
 emptyErrorReporter.hapi.plugin.register.attributes = { pkg: require('../package.json') };
 
-var emptyMetrics = {
+const emptyMetrics = {
   isActive: false,
-  gauge: noop,
-  increment: noop,
-  histogram: noop,
-  flush: noop,
-  setDefaultTags: noop
+  gauge: spy(),
+  increment: spy(),
+  histogram: spy(),
+  flush: spy(),
+  setDefaultTags: spy()
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "bunyan": "^1.8.1",
     "datadog-metrics": "^0.3.0",
     "pidusage": "^1.0.1",
-    "raven": "^0.10.0"
+    "raven": "^0.10.0",
+    "sinon": "^1.17.4"
   },
   "devDependencies": {
     "mocha": "^2.4.5",


### PR DESCRIPTION
Using spies will make testing that the lib is called with the correct values much easier. There is no need to override fields and it can keep using the stub proxies as they are.