### PR TITLE
Remove spy calls from production code

### DIFF
--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -1,21 +1,21 @@
-const spy = require('sinon').spy;
+const noop = function() {};
 
 const emptyMiddleware = function (a, b, next) { next(); };
 
 const emptyLogger = {
-  trace: spy(),
-  debug: spy(),
-  info: spy(),
-  warn: spy(),
-  error: spy(),
-  fatal: spy()
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop
 };
 
 const emptyErrorReporter = {
   isActive: false,
-  captureException: spy(),
-  captureMessage: spy(),
-  patchGlobal: spy(),
+  captureException: noop,
+  captureMessage: noop,
+  patchGlobal: noop,
   hapi: {
     plugin: {
       register: emptyMiddleware
@@ -30,11 +30,11 @@ emptyErrorReporter.hapi.plugin.register.attributes = { pkg: require('../package.
 
 const emptyMetrics = {
   isActive: false,
-  gauge: spy(),
-  increment: spy(),
-  histogram: spy(),
-  flush: spy(),
-  setDefaultTags: spy()
+  gauge: noop,
+  increment: noop,
+  histogram: noop,
+  flush: noop,
+  setDefaultTags: noop
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "datadog-metrics": "^0.3.0",
     "node-statsd": "^0.1.1",
     "pidusage": "^1.0.4",
-    "raven": "^0.10.0",
-    "sinon": "^1.17.4"
+    "raven": "^0.10.0"
   },
   "devDependencies": {
     "mocha": "^2.4.5",
     "nsp": "^2.5.0",
-    "mockuire": "^0.1.0"
+    "mockuire": "^0.1.0",
+    "sinon": "^1.17.4"
   }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -3,9 +3,12 @@
 const assert = require('assert');
 const sentry = require('../lib/error_reporter')({}, {});
 const logger = require('../lib/logger')({ name: 'test' }, { LOG_LEVEL: 'fatal' });
+const spy = require('sinon').spy;
 
 describe('logger', function() {
   beforeEach(function() {
+    sentry.captureException = spy();
+    sentry.captureMessage = spy();
     sentry.captureException.reset();
     sentry.captureMessage.reset();
   });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -10,6 +10,12 @@ const loggerStub = stubs.logger;
 const captureLog = logFormatter(loggerStub);
 const levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 
+const spy = require('sinon').spy;
+
+levels.forEach(function(lvl) {
+  loggerStub[lvl] = spy();
+});
+
 describe('Utils', function() {
   describe('logFormatter', function() {
     var logger = {};


### PR DESCRIPTION
This significantly improves performance (as in requests/second) and cpu/memory consumption.

Small (and primitive) benchmark script:
```js
const pkg = { name: 'benchmark' }
const env = process.env
const agent = require('./index')
agent.init(pkg, env)

const MAX = 1000000

var start = Date.now()
for(var i=0; i<MAX; i++) {
  agent.metrics.increment(`foo.bar${i}`)
}
var time = Date.now() - start
console.log(time)
```

Fake statsd daemon:

```js
const dgram = require('dgram');
const server = dgram.createSocket('udp4');
var c = 0;

server.on('error', (err) => {
  console.log(`server error:\n${err.stack}`);
});

server.on('message', (msg, rinfo) => {
  if ((c++ % 1000) === 0) {
    console.log(`server got: ${c} ${rinfo.address}:${rinfo.port}`);
  }
});

server.on('listening', () => {
  var address = server.address();
  console.log(`server listening ${address.address}:${address.port}`);
});

server.bind(8125);
```

You can start the fake statsd daemon and run the following commands to compare:

```sh
STATSD_HOST=localhost:8125 node bench.js
```

... to run with the metrics "on" or:

```sh
node bench.js
```

... to run with the metrics off.