### PR TITLE
Listen for udp socket error

### DIFF
--- a/lib/metrics_factory.js
+++ b/lib/metrics_factory.js
@@ -25,6 +25,7 @@ exports.create = (pkg, env) => {
 
   if (env.STATSD_HOST) {
     client = buildStatsD(pkg, env);
+    client.socket.on('error', function noop() {});
   } else if (env.METRICS_API_KEY) {
     client = buildDataDog(pkg, env);
   }


### PR DESCRIPTION
This is just a proposal. We can allow the user to pass in a function, or we can use the logger to actually push the message. Both are simple changes.
But as it stands right now, every single error that the lib might be generating at this point gets thrown out.

@Verlic @dirceu
