### PR TITLE
Fix issue for when second parameter is an array or error, or anything but a string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ exports.logFormatter = function(logger) {
   return function captureLog(lvl) {
     return function formatLog() {
       const args = Array.from(arguments);
-      if (typeof args[0] === 'string' && typeof args[1] === 'object') {
+      if (typeof args[0] === 'string' && typeof args[1] !== 'string') {
         const swap = args[0];
         args[0] = args[1];
         args[1] = swap;


### PR DESCRIPTION
There is an issue with the arguments swap on logFormatter that arrises when the argument expected to be 'typeof object' is actually something else: **Error**, **Array**, **Etc....**

The current PR fixes the problem evidenced by the example below.

When implemented the logger in auth0-manage, we found the following output in some scenarios:

```
[2017-02-23T19:25:24.419Z] DEBUG: auth0-manage/25580 on login: undefined 'Current tenant is: douce2 region: atlassian'
[2017-02-23T19:25:24.421Z] DEBUG: auth0-manage/25580 on login:
    [ { name: 'default', description: 'Default', tenants: [ 'douce' ] },
      { name: 'atlassian',
        description: 'Atlassian',
        tenants: [ 'douce2' ] } ] 'Region list'

```

Instead of this:

```
[2017-02-23T19:24:24.914Z] DEBUG: auth0-manage/24908 on login: Current tenant is: douce2 region: atlassian
[2017-02-23T19:24:24.914Z] DEBUG: auth0-manage/24908 on login: Region list
    0: {
      "name": "default",
      "description": "Default",
      "tenants": [
        "douce"
      ]
    }
    --
    1: {
      "name": "atlassian",
      "description": "Atlassian",
      "tenants": [
        "douce2"
      ]
    }

```
... which is the expected result.