### PR TITLE
Cover for cases where you only receive a text parameter and the second parameter is undefined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ exports.logFormatter = function(logger) {
       const args = Array.from(arguments);
       if (typeof args[0] === 'string' && typeof args[1] !== 'string') {
         const swap = args[0];
-        args[0] = args[1];
+        args[0] = args[1] || {};
         args[1] = swap;
       }
       return logger[lvl].apply(logger, args);


### PR DESCRIPTION
In cases where you passed only a string message as parameter, you'd see just `undefined some string message` logged.

This PR fixes that issue.