### PR TITLE
Added flush function

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -40,6 +40,14 @@ module.exports = function(pkg, env) {
     return metrics.histogram(name, value, getTags(tags));
   };
 
+  obj.flush = function(){
+    if (env.METRICS_API_KEY){
+      return metrics.flush();      
+    }
+    // STATSD does not require flush. 
+    return;
+  };
+
   obj.startResourceCollection = function() {
     if (env.COLLECT_RESOURCE_USAGE) {
       const tags = ['pid:' + process.pid];


### PR DESCRIPTION
Added flush method to be able to upload metrics from a console application immediately without waiting for the flush interval

You need to set the flush interval to 0 and execute `agent.metrics.flush()`