### PR TITLE
Adds two functions to track metric counts and duration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,10 +1,10 @@
 const blocked = require('blocked');
 const pusage = require('pidusage');
-
+const uuid = require('uuid');
 const utils = require('./utils');
 const metricsFactory = require('./metrics_factory');
 
-module.exports = function(pkg, env) {
+module.exports = function (pkg, env) {
   if (!env.STATSD_HOST && !env.METRICS_API_KEY) {
     return require('./stubs').metrics;
   }
@@ -13,22 +13,23 @@ module.exports = function(pkg, env) {
 
   const obj = {
     isActive: true,
-    __defaultTags: env.SERVICE_NAME ? [ `service_name:${env.SERVICE_NAME}` ] : []
+    trackIds: {},
+    __defaultTags: env.SERVICE_NAME ? [`service_name:${env.SERVICE_NAME}`] : []
   };
 
-  const getTags = function(tags) {
+  const getTags = function (tags) {
     return obj.__defaultTags.concat(utils.processTags(tags));
   };
 
-  obj.setDefaultTags = function(tags) {
+  obj.setDefaultTags = function (tags) {
     obj.__defaultTags = utils.processTags(tags);
   };
 
-  obj.gauge = function(name, value, tags) {
+  obj.gauge = function (name, value, tags) {
     return metrics.gauge(name, value, getTags(tags));
   };
 
-  obj.increment = function(name, value, tags) {
+  obj.increment = function (name, value, tags) {
     if (Array.isArray(value)) {
       tags = value;
       value = 1;
@@ -36,33 +37,51 @@ module.exports = function(pkg, env) {
     return metrics.increment(name, value, getTags(tags));
   };
 
-  obj.histogram = function(name, value, tags) {
+  obj.histogram = function (name, value, tags) {
     return metrics.histogram(name, value, getTags(tags));
   };
 
-  obj.flush = function(){
-    if (env.METRICS_API_KEY){
-      return metrics.flush();      
+  obj.flush = function () {
+    if (env.METRICS_API_KEY) {
+      return metrics.flush();
     }
-    // STATSD does not require flush. 
+    // STATSD does not require flush.
     return;
   };
 
-  obj.startResourceCollection = function() {
+  obj.time = function (metricName, tags) {
+    const id = uuid.v4();
+    obj.increment(`${metricName}.started`, 1, tags);
+    obj.trackIds[id] = Date.now();
+    return id;
+  };
+
+  obj.endTime = function (metricName, id, tags) {
+    if (!obj.trackIds[id]) {
+      return;
+    }
+
+    var time = Date.now() - obj.trackIds[id];
+    delete obj.trackIds[id];
+    obj.increment(`${metricName}.ended`, 1, tags);
+    obj.histogram('${metricName}.time', time, tags);
+  }
+
+  obj.startResourceCollection = function () {
     if (env.COLLECT_RESOURCE_USAGE) {
       const tags = ['pid:' + process.pid];
-      setInterval(function() {
+      setInterval(function () {
         var memUsage = process.memoryUsage();
         obj.gauge('resources.memory.heapTotal', memUsage.heapTotal, tags);
         obj.gauge('resources.memory.heapUsed', memUsage.heapUsed, tags);
-        pusage.stat(process.pid, function(err, stat) {
+        pusage.stat(process.pid, function (err, stat) {
           if (err) return;
           obj.gauge('resources.memory.usage', stat.memory, tags);
           obj.gauge('resources.cpu.usage', stat.cpu, tags);
         });
       }, env.COLLECT_RESOURCE_USAGE_INTERVAL || 5000);
 
-      blocked(function(ms) {
+      blocked(function (ms) {
         obj.histogram('event-loop.blocked', ms, tags);
       });
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "datadog-metrics": "^0.3.0",
     "node-statsd": "^0.1.1",
     "pidusage": "^1.0.4",
-    "raven": "^0.10.0"
+    "raven": "^0.10.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -35,6 +35,21 @@ describe('metrics', function() {
     done();
   });
 
+  it('should run track without throwing', function(done) {
+    assert.doesNotThrow(function() {
+      var id = metrics.time('foo.bar');
+      assert.ok(id);
+      metrics.endTime('foo.bar', id);
+      id = metrics.time('foo.bar', ['tag1:a', 'tag2:b']);
+      assert.ok(id);
+      metrics.endTime('foo.bar', id, ['tag1:a', 'tag2:b']);
+      id = metrics.time('foo.bar', {'tag1': 'a', 'tag2': 'b'});
+      metrics.endTime('foo.bar', id, {'tag1': 'a', 'tag2': 'b'});
+      assert.ok(id);
+    }, TypeError);
+    done();
+  });
+
   it('should run histogram without throwing', function(done) {
     assert.doesNotThrow(function() {
       metrics.gauge('foo.bar', 5.5);


### PR DESCRIPTION
This PR adds two functions to help counting and measuring the duration of an operation.

- `time`: increments the metric _started_ by 1 and tracks the start time of the operation returning a track id.
- `endTime`: increments the metric _ended_ by 1 and sends the histogram metric using the trackId to calculate the duration of the operation.

For example:

```
var trackId = metrics.time('myoperation', { tag: value });

doAsyncOperation(function(result) {
   metrics.endTime('myoperation', trackId, { tag: value, result: result });
});
```