### PR TITLE
Changes endTime function to use the track id to collect the metric name

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -52,16 +52,17 @@ module.exports = function (pkg, env) {
   obj.time = function (metricName, tags) {
     const id = uuid.v4();
     obj.increment(`${metricName}.started`, 1, tags);
-    obj.trackIds[id] = Date.now();
+    obj.trackIds[id] = { date: Date.now(), metricName: metricName };
     return id;
   };
 
-  obj.endTime = function (metricName, id, tags) {
+  obj.endTime = function (id, tags) {
     if (!obj.trackIds[id]) {
       return;
     }
 
-    var time = Date.now() - obj.trackIds[id];
+    const metricName = obj.trackIds[id].metricName;
+    var time = Date.now() - obj.trackIds[id].date;
     delete obj.trackIds[id];
     obj.increment(`${metricName}.ended`, 1, tags);
     obj.histogram('${metricName}.time', time, tags);

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -39,12 +39,12 @@ describe('metrics', function() {
     assert.doesNotThrow(function() {
       var id = metrics.time('foo.bar');
       assert.ok(id);
-      metrics.endTime('foo.bar', id);
+      metrics.endTime(id);
       id = metrics.time('foo.bar', ['tag1:a', 'tag2:b']);
       assert.ok(id);
-      metrics.endTime('foo.bar', id, ['tag1:a', 'tag2:b']);
+      metrics.endTime(id, ['tag1:a', 'tag2:b']);
       id = metrics.time('foo.bar', {'tag1': 'a', 'tag2': 'b'});
-      metrics.endTime('foo.bar', id, {'tag1': 'a', 'tag2': 'b'});
+      metrics.endTime(id, {'tag1': 'a', 'tag2': 'b'});
       assert.ok(id);
     }, TypeError);
     done();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -33,7 +33,7 @@ describe('Utils', function() {
     it('should not modify str logs', function() {
       levels.forEach(function(lvl) {
         logger[lvl]('test');
-        assert(loggerStub[lvl].calledWith('test'));
+        assert(loggerStub[lvl].calledWith({}, 'test'));
       });
     });
     it('should not modify bunyan compatible logs', function() {


### PR DESCRIPTION
It's no longer necessary to send the `metricName` for the `endTime()` function as we use the internal track id to retrieve it.