### PR TITLE
[WIP] Remove additional streams from logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # auth0-instrumentation
 
-The goal of this package is to make it easier to collect information about our services through logs, metrics and error catching.
+The goal of this package is to make it easier to collect information about our services through logs, metrics, and error catching.
 
 ## Logs
 
-With the right configuration, logs will go from the local server to "THE CLOUD", then a bunch of awesome stuff will happen and they'll become available on [Kibana](https://www.elastic.co/products/kibana).
+By default, logs will be sent to the standard output; log collectors (like [fluentd](https://www.fluentd.org)) might be used to send them to other places like [Kibana](https://www.elastic.co/products/kibana).
 
-The logger is powered by [bunyan](https://github.com/trentm/node-bunyan), check their documentation for best practices.
+The logger is powered by [pino](https://github.com/pinojs/pino), check their documentation for best practices.
 
 Usage:
 
 ```js
-var serializers = require('./serializers'); // See https://github.com/trentm/node-bunyan#serializers
+var serializers = require('./serializers'); // works just like https://github.com/trentm/node-bunyan#serializers
 var pkg = require('./package.json');
 var env = require('./lib/env');
 var agent = require('auth0-instrumentation');
@@ -148,41 +148,13 @@ const env = {
   // general configuration
   'CONSOLE_LOG_LEVEL': 'info', // log level for console
 
-  // AWS configuration for Kinesis
-  'AWS_ACCESS_KEY_ID': undefined,
-  'AWS_ACCESS_KEY_SECRET': undefined,
-  'AWS_REGION': undefined
-
-  // Kinesis configuration (single stream)
-  'LOG_TO_KINESIS': undefined, // Kinesis stream name
-  'LOG_TO_KINESIS_LEVEL': 'info', // log level for Kinesis
-  'LOG_TO_KINESIS_LOG_TYPE': undefined, // bunyan stream type
-  'KINESIS_OBJECT_MODE': true,
-  'KINESIS_TIMEOUT': 5,
-  'KINESIS_LENGTH': 50,
-
-  // Kinesis configuration (pool of streams for failover)
-  'KINESIS_POOL': [
-    {
-      // if any of this config options are undefined will take root level,
-      // if exists
-      'LOG_TO_KINESIS': undefined, // Kinesis stream name
-      'LOG_TO_KINESIS_LEVEL': 'info', // log level for Kinesis
-      'LOG_TO_KINESIS_LOG_TYPE': undefined, // bunyan stream type
-      'AWS_ACCESS_KEY_ID': undefined,
-      'AWS_ACCESS_KEY_SECRET': undefined,
-      'AWS_REGION': undefined,
-      'IS_PRIMARY': undefined // set as true for the kinesis instance you want to work as primary
-
-    }
-  ]
-
   // Error reporter configuration
   'ERROR_REPORTER_URL': undefined, // Sentry URL
   'ERROR_REPORTER_LOG_LEVEL': 'error',
 
   // Metrics collector configuration
   'METRICS_API_KEY': undefined, // DataDog API key
+  'STATSD_HOST': undefined, // to use statsd or dogstatsd instead of the DataDog API
   'METRICS_HOST': require('os').hostname(),
   'METRICS_PREFIX': pkg.name + '.',
   'METRICS_FLUSH_INTERVAL': 15 // seconds

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,116 +1,37 @@
-const bunyan = require('bunyan');
-const SentryStream = require('bunyan-sentry-stream').SentryStream;
-const ProcessInfo = require('auth0-common-logging').ProcessInfo;
-const Serializers = require('auth0-common-logging').Serializers;
-const HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableStream;
-const KinesisWritable = require('aws-kinesis-writable');
-const KinesisStreamPool = require('aws-kinesis-writable').pool;
+const pino = require('pino');
+const _ = require('lodash');
+const processInfo = require('auth0-common-logging').ProcessInfo;
+const defaultSerializers = require('auth0-common-logging').Serializers;
 
-const utils = require('./utils');
-const ErrorReporter = require('./error_reporter');
-const KeepAliveAgent = require('./keep_alive_agent');
-const logFormatter = require('./utils').logFormatter;
+function logSerializer(logger, defaults) {
+  return function captureLog(lvl) {
+    return function serializeLog() {
+      const args = Array.from(arguments);
+      if (typeof args[0] === 'string' && typeof args[1] !== 'string') {
+        const swap = args[0];
+        args[0] = args[1] || {};
+        args[1] = swap;
+      }
+      args[0] = _.defaults(args[0], defaults);
+      return logger[lvl].apply(logger, args);
+    };
+  };
+};
 
 module.exports = function getLogger(pkg, env, serializers) {
-  if (!serializers) {
-    serializers = Serializers;
-  }
-
-  var bunyan_streams = [{
-    level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
-    stream: process.stdout
-  }];
-
-  if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
-    var httpStream = new HttpWritableStream(env.LOG_TO_WEB_URL);
-    httpStream.on('error', function(err) {
-      if (err) {
-        console.error('Error on writing logs to web url', JSON.stringify({
-          message: err.message,
-          stack: err.stack
-        }));
-      } else {
-        console.error('Error on writing logs to web url');
-      }
-    });
-    bunyan_streams.push({
-      name: 'web-url',
-      stream: httpStream,
-      level: env.LOG_TO_WEB_LEVEL || 'error'
-    });
-  }
-
-  if (env.LOG_TO_KINESIS || env.KINESIS_POOL) {
-    var keepAliveAgent = KeepAliveAgent(env);
-    var stream;
-
-    if (env.KINESIS_POOL) {
-      // pool for failover
-      var kinesisStreams = env.KINESIS_POOL.map(function(config) {
-        // prioritize pool config over global but if not in pool, take global (e.g. AWS_REGION)
-        var kinesisInstance = new KinesisWritable(utils.buildKinesisOptions(Object.assign({}, env, config), keepAliveAgent));
-        if (config.IS_PRIMARY) {
-          kinesisInstance.primary = true;
-        }
-        return kinesisInstance;
-      });
-      stream = new KinesisStreamPool({
-        streams: kinesisStreams
-      });
-    } else {
-      // single stream, no failover
-      stream = new KinesisWritable(utils.buildKinesisOptions(env, keepAliveAgent));
-    }
-
-    var streamErrorHandler = function(err) {
-      if (err) {
-        console.error('Error on writing logs to Kinesis', JSON.stringify({
-          message: err.message,
-          records: err.records,
-          stack: err.stack
-        }));
-      } else {
-        console.error('Error on writing logs to Kinesis');
-      }
-    };
-
-    stream.on('error', streamErrorHandler);
-    stream.on('poolFailure', streamErrorHandler);
-
-    bunyan_streams.push({
-      name: 'kinesis',
-      stream: stream,
-      level: env.LOG_TO_KINESIS_LEVEL,
-      type: env.LOG_TO_KINESIS_LOG_TYPE
-    });
-
-  }
-
-  bunyan_streams.push({
-    name: 'sentry',
-    stream: new SentryStream(ErrorReporter(pkg, env)),
-    level: env.ERROR_REPORTER_LOG_LEVEL || 'error',
-    type: 'raw'
+  const logger = pino({
+    name: pkg.name,
+    serializers: serializers || defaultSerializers,
+    level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL || 'info',
+    slowTime: true,
+    extreme: env.BUFFER_LOGS
   });
 
-  const process_info = ProcessInfo &&
-    !env.IGNORE_PROCESS_INFO &&
-    ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined;
-
-  const logger = bunyan.createLogger({
-    name:         pkg.name,
-    process:      process_info,
-    region:       env.AWS_REGION || undefined,
+  const captureLog = logSerializer(logger, {
+    process: !env.IGNORE_PROCESS_INFO ? processInfo : undefined,
+    region: env.AWS_REGION || undefined,
     service_name: env.SERVICE_NAME || undefined,
-    streams:      bunyan_streams,
-    serializers:  serializers
   });
-
-  logger.on('error', function(err, stream) {
-    console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
-  });
-
-  const captureLog = logFormatter(logger);
 
   return {
     trace: captureLog('trace'),

--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
   "license": "ISC",
   "dependencies": {
     "auth0-common-logging": "github:auth0/auth0-common-logging#v2.12.1",
-    "aws-kinesis-writable": "~2.0.0",
     "blocked": "^1.2.1",
-    "bunyan": "^1.8.1",
-    "bunyan-sentry-stream": "^1.0.2",
     "datadog-metrics": "^0.3.0",
     "node-statsd": "^0.1.1",
     "pidusage": "^1.0.4",
+    "pino": "^4.5.2",
     "raven": "^0.10.0",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
This change (a major, breaking one) vastly simplifies the logger, moving the responsibility of pushing logs to external places (kinesis, web url, sentry) to a log collector process like fluentd.

The gains here are removing overhead and improving performance on the services using this library.

By running a small benchmark script (logging 1 million log entries to a single stream, the standard output) we consistently got results that were 30-40%+ better:

```
current-logger: 20345.571ms
new-logger: 11355.485ms
```