### PR TITLE
Adds callback noop to avoid throwing exceptions to caller process

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,6 +5,7 @@ const utils = require('./utils');
 const metricsFactory = require('./metrics_factory');
 const stubs = require('./stubs').metrics;
 
+
 module.exports = function (pkg, env) {
   if (!env.STATSD_HOST && !env.METRICS_API_KEY) {
     return stubs;
@@ -31,20 +32,23 @@ module.exports = function (pkg, env) {
     obj.__defaultTags = utils.processTags(tags);
   };
 
-  obj.gauge = function (name, value, tags) {
-    return metrics.gauge(name, value, getTags(tags));
+  obj.gauge = function (name, value, tags, callback) {
+    callback = callback || stubs.callback;
+    return metrics.gauge(name, value, getTags(tags), callback);
   };
 
-  obj.increment = function (name, value, tags) {
+  obj.increment = function (name, value, tags, callback) {
+    callback = callback || stubs.callback;
     if (Array.isArray(value)) {
       tags = value;
       value = 1;
     }
-    return metrics.increment(name, value, getTags(tags));
+    return metrics.increment(name, value, getTags(tags), callback);
   };
 
-  obj.histogram = function (name, value, tags) {
-    return metrics.histogram(name, value, getTags(tags));
+  obj.histogram = function (name, value, tags, callback) {
+    callback = callback || stubs.callback;
+    return metrics.histogram(name, value, getTags(tags), callback);
   };
 
   obj.flush = function () {

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -37,7 +37,8 @@ const emptyMetrics = {
   setDefaultTags: noop,
   startResourceCollection: noop,
   time: returnValue,
-  endTime: noop
+  endTime: noop,
+  callback: noop
 };
 
 const emptyProfiler = {


### PR DESCRIPTION
This PR adds callback support to the metrics functions `gauge`, `increment`, and `histogram`. This has two purposes:

- Allow having a callback after the metric is sent
- Prevent from receiving an exception from the node-statsd library if no callback is present and an error is thrown.
