### PR TITLE
Make profiler work in single process mode

### DIFF
--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -6,6 +6,9 @@ const GcStats = require('gc-stats');
 const v8Profiler = require('v8-profiler-node8');
 const debounce = require('lodash.debounce');
 
+// Make it not crash when SIGUSR2 is invoked in single process mode (e.g. vagrant).
+process.send = process.send || function () {};
+
 function Profiler(agent, pkg, env) {
   this.huntMemoryLeaks = env.HUNT_MEMORY_LEAKS;
   this.agent = agent;

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -15,8 +15,6 @@ describe('Profiler', function() {
       }
     };
     profiler = new Profiler(agent, {name: 'test'}, {HUNT_MEMORY_LEAKS: true});
-    // avoid having to create workers
-    process.send = function() {};
   });
   afterEach(function() {
     process.send = undefined;


### PR DESCRIPTION
Adding a `noop` `process.send` if none is declared.

This makes the profiler work in vagrant (and possibly other single process environments).
