### PR TITLE
Implement support for child loggers

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,7 +8,7 @@ const KinesisWritable = require('aws-kinesis-writable');
 const utils = require('./utils');
 const ErrorReporter = require('./error_reporter');
 const KeepAliveAgent = require('./keep_alive_agent');
-const logFormatter = require('./utils').logFormatter;
+const decorateLogger = require('./utils').decorateLogger;
 
 module.exports = function getLogger(pkg, env, serializers) {
   if (!serializers) {
@@ -91,14 +91,5 @@ module.exports = function getLogger(pkg, env, serializers) {
     console.error('Cannot write to log stream ' + stream.name + ' ' + (err && err.message));
   });
 
-  const captureLog = logFormatter(logger);
-
-  return {
-    trace: captureLog('trace'),
-    debug: captureLog('debug'),
-    info: captureLog('info'),
-    warn: captureLog('warn'),
-    error: captureLog('error'),
-    fatal: captureLog('fatal')
-  };
+  return decorateLogger(logger);
 };

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -1,8 +1,10 @@
 const noop = function() {};
+const returnEmptyLogger = function() { return emptyLogger; };
 const returnValue = function() { return 1; };
 const emptyMiddleware = function (a, b, next) { next(); };
 
 const emptyLogger = {
+  child: returnEmptyLogger,
   trace: noop,
   debug: noop,
   info: noop,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,8 +38,13 @@ exports.buildKinesisOptions = function (configMap, keepAliveAgent) {
   };
 };
 
-exports.logFormatter = function(logger) {
-  return function captureLog(lvl) {
+exports.decorateLogger = function(logger) {
+  const createChildLoggerFactory = function(logger) {
+    return function child(childOptions, simple) {
+      return exports.decorateLogger(logger.child(childOptions, simple));
+    };
+  };
+  const createLogFormatter = function(logger, lvl) {
     return function formatLog() {
       const args = Array.from(arguments);
       if (typeof args[0] === 'string' && typeof args[1] !== 'string') {
@@ -49,5 +54,15 @@ exports.logFormatter = function(logger) {
       }
       return logger[lvl].apply(logger, args);
     };
+  };
+
+  return {
+    child: createChildLoggerFactory(logger),
+    trace: createLogFormatter(logger, 'trace'),
+    debug: createLogFormatter(logger, 'debug'),
+    info: createLogFormatter(logger, 'info'),
+    warn: createLogFormatter(logger, 'warn'),
+    error: createLogFormatter(logger, 'error'),
+    fatal: createLogFormatter(logger, 'fatal')
   };
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -4,10 +4,9 @@ const assert = require('assert');
 
 const stubs = require('../lib/stubs');
 const utils = require('../lib/utils');
-const logFormatter = utils.logFormatter;
+const decorateLogger = utils.decorateLogger;
 const loggerStub = stubs.logger;
 
-const captureLog = logFormatter(loggerStub);
 const levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 
 const spy = require('sinon').spy;
@@ -17,13 +16,8 @@ levels.forEach(function(lvl) {
 });
 
 describe('Utils', function() {
-  describe('logFormatter', function() {
-    var logger = {};
-    before(function() {
-      levels.forEach(function(lvl) {
-        logger[lvl] = captureLog(lvl);
-      });
-    });
+  describe('decorateLogger', function() {
+    var logger = decorateLogger(loggerStub);
 
     afterEach(function() {
       levels.forEach(function(lvl) {


### PR DESCRIPTION
- Adds support for the function `agent.logger.child()`, based on the [bunyan feature](https://github.com/trentm/node-bunyan/blob/fe31b83e42d9c7f784e83fdcc528a7c76e0dacae/README.md#logchild) and having the signature `function(childOptions, simple)` where:
  - `childOptions` is an object whose properties will be baked into log records emitted by the child logger that is returned
  - `simple` as described in the [bunyan README](https://github.com/trentm/node-bunyan/blob/fe31b83e42d9c7f784e83fdcc528a7c76e0dacae/README.md#logchild)
