### PR TITLE
Adding more randomness into the partitionKey

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,7 @@ exports.buildKinesisOptions = function (configMap, keepAliveAgent) {
     sessionToken: configMap.AWS_SESSION_TOKEN,
     streamName: configMap.LOG_TO_KINESIS,
     region: configMap.AWS_KINESIS_REGION || configMap.AWS_REGION,
+    partitionKey: function getPartitionKey() { return Date.now().toString() + Math.random(); },
     httpOptions: {
       agent: keepAliveAgent
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "blocked": "^1.2.1",
     "bunyan": "^1.8.1",
     "datadog-metrics": "^0.3.0",
-    "gc-stats": "^1.0.2",
+    "gc-stats": "1.0.2",
     "lodash.debounce": "^4.0.8",
     "lodash.omit": "^4.5.0",
     "moment": "^2.18.1",


### PR DESCRIPTION
Ignore any passed arguments and use a ts in ms concatenated to a random number

Today we have more than 2500 records with the same timestamp in ms, so, going to the same kinesis shardId, we need more randomness to be free to add more shards and to not hit the throughput exceeded error