### PR TITLE
Introduce CONSOLE_NICE_FORMAT

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,16 +9,30 @@ const utils = require('./utils');
 const ErrorReporter = require('./error_reporter');
 const KeepAliveAgentRegistry = require('./keep_alive_agent');
 const decorateLogger = require('./utils').decorateLogger;
+const spawn = require('child_process').spawn;
 
 module.exports = function getLogger(pkg, env, serializers, agent) {
   if (!serializers) {
     serializers = Serializers;
   }
 
-  var bunyan_streams = [{
-    level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
-    stream: process.stdout
-  }];
+  const bunyan_streams = [];
+
+  if (env.CONSOLE_NICE_FORMAT) {
+    const bunyanFormatter = spawn(`${__dirname}/../node_modules/.bin/bunyan`,
+                                  [ '--color' ], {
+                                    stdio: [ 'pipe', 'inherit', 'inherit' ]
+                                  });
+    bunyan_streams.push({
+      level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
+      stream: bunyanFormatter.stdin
+    });
+  } else {
+    bunyan_streams.push({
+      level: env.CONSOLE_LOG_LEVEL || env.LOG_LEVEL,
+      stream: process.stdout
+    });
+  }
 
   if (process.env.NODE_ENV === 'production' && env.LOG_TO_WEB_URL) {
     var httpStream = new HttpWritableStream(env.LOG_TO_WEB_URL);


### PR DESCRIPTION
Introduce a variable called `CONSOLE_NICE_FORMAT` to push bunyan nice-formatted messages to stdout/stderr instead of json.