### PR TITLE
Update release notes for v2.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+<a name="v2.11.4"></a>
+# v2.11.4
+### Infrastructure Changes
+* Introduced `CONSOLE_NICE_FORMAT`
+* Replaced `debounce` with `lodash.throttle@4.1.1`
+* https://github.com/auth0/auth0-instrumentation/compare/v2.11.3...v2.11.4
+
 <a name="v2.11.3"></a>
 # v2.11.3
 ### Infrastructure Changes

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -79,14 +79,14 @@ module.exports = function getLogger(pkg, env, serializers, agent) {
     });
 
   }
-  if (env.ERROR_REPORTER_URL) {
-    bunyan_streams.push({
-      name: 'sentry',
-      stream: new Auth0SentryStream(ErrorReporter(pkg, env)),
-      level: env.ERROR_REPORTER_LOG_LEVEL || 'error',
-      type: 'raw'
-    });
-  }
+
+  bunyan_streams.push({
+    name: 'sentry',
+    stream: new Auth0SentryStream(ErrorReporter(pkg, env)),
+    level: env.ERROR_REPORTER_LOG_LEVEL || 'error',
+    type: 'raw'
+  });
+
 
   const process_info = ProcessInfo &&
     !env.IGNORE_PROCESS_INFO &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update the CHANGELOG and back out the change in which Sentry would only run if `ERROR_REPORTER_URL` was set