### PR TITLE
WIP: Add static average sampling for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ metrics.increment('some.other.thing', 5, tags); // increment by 5
 metrics.histogram('service.time', 0.248);
 ```
 
+### Metric sampling
+
+You can set up a sampling rate for any given service by setting up `env.SAMPLING_RATE`; you can override that in any given metrics-collection call by passing the tag `sampling_rate`. Example:
+
+```js
+var pkg = require('./package.json');
+var env = require('./lib/env');
+env.SAMPLING_RATE = 80;
+var agent = require('auth0-instrumentation');
+agent.init(pkg, env);
+var metrics = agent.metrics;
+
+// 80% of these metrics calls should go through, as per env.SAMPLING_RATE
+metrics.increment('requests.served', {'http-status':200});
+
+// all of these metrics calls should go through; we care more about errors
+// than successful scenarios, in this case
+metrics.increment('requests.served', {'http-status':500, 'sampling_rate':100});
+```
+
 ## Errors
 
 You can use the error reporter to send exceptions to an external service. You can set it up on your app in three ways, depending on what framework is being used.

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -16,7 +16,8 @@ module.exports = function (pkg, env) {
   const obj = {
     isActive: true,
     trackIds: {},
-    __defaultTags: []
+    __defaultTags: [],
+    defaultSamplingRate: env.SAMPLING_RATE
   };
 
   if (env.SERVICE_NAME) {
@@ -25,7 +26,11 @@ module.exports = function (pkg, env) {
     obj.__defaultTags.push(`service_name:${pkg.name}`);
   }
   const getTags = function (tags) {
-    return obj.__defaultTags.concat(utils.processTags(tags));
+    tags = utils.processTags(tags);
+    if(tags.sampling_rate || obj.defaultSamplingRate) {
+      tags.sampling_rate = tags.sampling_rate || obj.defaultSamplingRate;
+    }
+    return obj.__defaultTags.concat(tags);
   };
 
   obj.setDefaultTags = function (tags) {
@@ -34,7 +39,9 @@ module.exports = function (pkg, env) {
 
   obj.gauge = function (name, value, tags, callback) {
     callback = callback || stubs.callback;
-    return metrics.gauge(name, value, getTags(tags), callback);
+    tags = getTags(tags);
+    if (!utils.sample(tags && tags.sampling_rate)) return;
+    return metrics.gauge(name, value, tags, callback);
   };
 
   obj.increment = function (name, value, tags, callback) {
@@ -43,12 +50,16 @@ module.exports = function (pkg, env) {
       tags = value;
       value = 1;
     }
-    return metrics.increment(name, value, getTags(tags), callback);
+    tags = getTags(tags);
+    if (!utils.sample(tags && tags.sampling_rate)) return;
+    return metrics.increment(name, value, tags, callback);
   };
 
   obj.histogram = function (name, value, tags, callback) {
     callback = callback || stubs.callback;
-    return metrics.histogram(name, value, getTags(tags), callback);
+    tags = getTags(tags);
+    if (!utils.sample(tags && tags.sampling_rate)) return;
+    return metrics.histogram(name, value, tags, callback);
   };
 
   obj.flush = function () {
@@ -60,6 +71,12 @@ module.exports = function (pkg, env) {
   };
 
   obj.time = function (metricName, tags) {
+    // if we're sampling and this didn't cross the threshold,
+    // ignore and return an API-compliant ID. This will be
+    // safely ignored later by `obj.endTime`
+    if (!utils.sample(tags && tags.sampling_rate)) {
+      return { date: Date.now(), metricName: metricName };
+    }
     const id = uuid.v4();
     obj.increment(`${metricName}.started`, 1, tags);
     obj.trackIds[id] = { date: Date.now(), metricName: metricName };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,3 +68,8 @@ exports.decorateLogger = function(logger) {
     fatal: createLogFormatter(logger, 'fatal')
   };
 };
+
+exports.sample = function(rate) {
+  if (!rate || isNaN(parseFloat(rate))) return true;
+  return parseInt(Math.random()*rate)%rate == 0;
+}


### PR DESCRIPTION
This is a simple implementation of static sampling (as described [here](https://honeycomb.io/blog/2017/02/instrumenting-high-volume-services-part-1/)).

A few important considerations:
1. If we have alerts on correlated metrics, using a smaller sample rate should be a problem. For instance, if we alert on `requests.received` vs. `requests.replied` we should either remove that alert and accept the information loss OR use a sample rate of 100.
1. This is not "smart", as it holds no context about a given transaction/request. This means that we can't ensure that all metrics for any given request will be published; it could be implemented as an improvement point, along with [dynamic sampling](https://honeycomb.io/blog/2017/03/instrumenting-high-volume-services-part-3/).
1. Most statsd clients support passing a `sample_rate` parameter (but not all) and they don't enforce the same sampling method, which is why sampling is implemented by "brute force" conditional.