### PR TITLE
Avoid pushing debug/info logs to Sentry as exceptions

### DIFF
--- a/lib/auth0_sentry_stream.js
+++ b/lib/auth0_sentry_stream.js
@@ -32,7 +32,7 @@ class Auth0SentryStream {
       tags.log_type = record.log_type;
     }
 
-    if (err) {
+    if (err && level !== 'info') {
       const extra = omit(record, 'err', 'tags');
       this.client.captureException(this.deserializeError(err), { extra, level, tags });
     } else {


### PR DESCRIPTION
We shouldn't be alerted to events like this:
https://sentry.io/auth0/auth0-users/issues/432345924/

... Which is being treated as an exception just because the log record
happens to have the `err` field:
https://github.com/auth0gnarea/auth0-users/blob/fbb3a5aa660d41dc647ed01a5cb04f8ae24b8796/lib/middleware/errors/unhandledErrors.js#L36

Originally reported in auth0-users but we think it may be best to tackle the issue here: https://github.com/auth0/auth0-users/pull/990