### PR TITLE
Removed sentry bridge

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -85,14 +85,6 @@ module.exports = function getLogger(pkg, env, serializers, agent) {
 
   }
 
-  bunyan_streams.push({
-    name: 'sentry',
-    stream: new Auth0SentryStream(ErrorReporter(pkg, env)),
-    level: env.ERROR_REPORTER_LOG_LEVEL || 'error',
-    type: 'raw'
-  });
-
-
   const process_info = ProcessInfo &&
     !env.IGNORE_PROCESS_INFO &&
     ProcessInfo.version !== '0.0.0' ? ProcessInfo : undefined;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -2,8 +2,8 @@
 
 const assert = require('assert');
 const sentry = require('../lib/error_reporter')({}, {});
-const logger = require('../lib/logger')({ name: 'test' }, 
-                                        { LOG_LEVEL: 'fatal', 
+const logger = require('../lib/logger')({ name: 'test' },
+                                        { LOG_LEVEL: 'fatal',
                                           PURPOSE: 'test-purpose',
                                           ENVIRONMENT: 'test-env',
                                           AWS_REGION: 'test-region'
@@ -11,89 +11,5 @@ const logger = require('../lib/logger')({ name: 'test' },
 const spy = require('sinon').spy;
 
 describe('logger', function() {
-  beforeEach(function() {
-    sentry.captureException = spy();
-    sentry.captureMessage = spy();
-    sentry.captureException.reset();
-    sentry.captureMessage.reset();
-  });
-
-  describe('logger.child()', function() {
-    it('should support creating child loggers', function() {
-      const childLogger = logger.child({
-        child: 'child'
-      });
-
-      childLogger.error({
-        log_type: 'not really an error'
-      }, 'test');
-      assert(sentry.captureException.calledOnce === false);
-      assert(sentry.captureMessage.calledOnce);
-      assert(sentry.captureMessage.getCall(0).args[1].tags.log_type, 'not really an error');
-      assert(sentry.captureMessage.getCall(0).args[1].extra.child, 'child');
-    });
-
-    it('should support creating nested child loggers', function() {
-      const childLogger = logger.child({
-        child: 'child'
-      });
-      const grandChildLogger = childLogger.child({
-        child: 'grandchild',
-        parent: 'child',
-      });
-
-      grandChildLogger.error({
-        log_type: 'not really an error'
-      }, 'test');
-      assert(sentry.captureException.calledOnce === false);
-      assert(sentry.captureMessage.calledOnce);
-      assert(sentry.captureMessage.getCall(0).args[1].tags.log_type, 'not really an error');
-      assert(sentry.captureMessage.getCall(0).args[1].extra.child, 'grandchild');
-      assert(sentry.captureMessage.getCall(0).args[1].extra.parent, 'child');
-    });
-  });
-
-  describe('SentryStream', function() {
-    it('should call captureException on error when level is error', function() {
-      logger.error(new Error('test'));
-      assert(sentry.captureException.calledOnce);
-      assert(sentry.captureMessage.calledOnce === false);
-    });
-
-    it('should call captureMessage on string when level is error', function() {
-      logger.error('test');
-      assert(sentry.captureException.calledOnce === false);
-      assert(sentry.captureMessage.calledOnce);
-    });
-
-    it('should add a log_type tag when the log entry has an error and has a log_type property', function() {
-      logger.error({
-        log_type: 'uncaughtException',
-        err: new Error('test err')
-      }, 'test');
-      assert(sentry.captureException.calledOnce);
-      assert(sentry.captureMessage.calledOnce === false);
-      assert(sentry.captureException.getCall(0).args[1].tags.log_type, 'uncaughtException');
-    });
-
-    it('should add a log_type tag when the log entry does not have an error and has a log_type property', function() {
-      logger.error({
-        log_type: 'not really an error'
-      }, 'test');
-      assert(sentry.captureException.calledOnce === false);
-      assert(sentry.captureMessage.calledOnce);
-      assert(sentry.captureMessage.getCall(0).args[1].tags.log_type, 'not really an error');
-    });
-  });
-
-  it('should add default values from environment', function() {
-    logger.error('testing');
-    assert(sentry.captureException.calledOnce === false);
-    assert(sentry.captureMessage.calledOnce);
-    const captured = sentry.captureMessage.getCall(0).args[1];
-    assert.equal(captured.extra.purpose, 'test-purpose');
-    assert.equal(captured.extra.environment, 'test-env');
-    assert.equal(captured.extra.region, 'test-region');
-  });
 
 });


### PR DESCRIPTION
### What?
When an error was logged it used to be sent to sentry, we are removing that.

### Why?
It was causing too much noise in sentry and making it hard to debug errors.

### References
- [Jira](Test)