### PR TITLE
Make `endTime` return the elapsed time

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -101,6 +101,7 @@ module.exports = function (pkg, env) {
     delete obj.trackIds[id];
     obj.increment(`${metricName}.ended`, 1, tags);
     obj.histogram(`${metricName}.time`, time, tags);
+    return time;
   };
 
   obj.startResourceCollection = function (tags) {


### PR DESCRIPTION
With this change, we can easily get the time spent on an operation to use it elsewhere. One example:

```js
let tags = { cache: 'hit' };
let took = agent.metrics.endTime(timerId, tags);
agent.metrics.observeBucketed('feature_flags.client.getFlags', took, [5, 10, 20, 50, 100, 500], tags);
agent.logger.info('Ended feature_flags.client.getFlags', tags);
```