### PR TITLE
Add initial tracing hooks to instrumentation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@ var Logger = require('./lib/logger');
 var ErrorReporter = require('./lib/error_reporter');
 var Metrics = require('./lib/metrics');
 var Profiler = require('./lib/profiler');
-
+var Tracer = require('./lib/tracer');
 
 module.exports = {
   logger: stubs.logger,
   errorReporter: stubs.errorReporter,
   metrics: stubs.metrics,
   profiler: stubs.profiler,
+  tracer: stubs.tracer,
   initialized: false,
 
   init: function(pkg, env, serializers, params) {
@@ -19,6 +20,7 @@ module.exports = {
     this.errorReporter = ErrorReporter(pkg, env);
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
+    this.tracer = Tracer(this, pkg, env);
     this.initialized = true;
 
     if (params && params.fileRotationSignal && env.LOG_FILE) {

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -17,7 +17,7 @@ var emptyTracer = {
   startSpan: () => { return emptySpan; },
   inject: noop,
   extract: returnNull
-}
+};
 
 const emptyLogger = {
   child: returnEmptyLogger,

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -1,7 +1,23 @@
 const noop = function() {};
 const returnEmptyLogger = function() { return emptyLogger; };
 const returnValue = function() { return 1; };
+const returnNull = () => { return null; };
 const emptyMiddleware = function (a, b, next) { if (next) { next(); } };
+
+var emptySpan = {
+  finish: noop,
+  setTag: noop,
+  addTags: noop,
+  context: returnNull,
+  tracer: () => { return emptyTracer },
+  setOperationName: noop,
+};
+
+var emptyTracer = {
+  startSpan: () => { return emptySpan; },
+  inject: noop,
+  extract: returnNull
+}
 
 const emptyLogger = {
   child: returnEmptyLogger,
@@ -57,5 +73,6 @@ module.exports = {
   logger: emptyLogger,
   errorReporter: emptyErrorReporter,
   metrics: emptyMetrics,
-  profiler: emptyProfiler
+  profiler: emptyProfiler,
+  tracer: emptyTracer
 };

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -1,0 +1,87 @@
+const tracing = require('opentracing');
+const tracerFactory = require('./tracer_factory');
+
+const noop = function() {};
+
+module.exports = function Tracer(agent, pkg, env) {
+
+  const tracer = tracerFactory.create(agent, pkg, env);
+
+  const obj = {
+    _tracer: tracer,
+    _logger: agent.logger,
+    FORMAT_HTTP_HEADERS: tracing.FORMAT_HTTP_HEADERS,
+    FORMAT_TEXT_MAP: tracing.FORMAT_TEXT_MAP
+  };
+
+  obj.Tags = Object.assign({
+    AUTH0_TENANT: 'auth0.tenant',
+    AUTH0_ENVIRONMENT: 'auth0.environment',
+    AUTH0_CHANNEL: 'auth0.channel'
+  }, tracing.Tags);
+
+  // Wrap the native opentracing 'span' object
+  // with a reduced API that discourages the use
+  // of features we don't want to use yet, while
+  // also giving us a place to hook additional
+  // functionality.
+  obj._wrapSpan = function(srcSpan) {
+    const span = Object.create(srcSpan);
+
+    // Disable baggage.
+    span.getBaggageItem = noop;
+    span.setBaggageItem = noop;
+
+    // Disable logging.
+    span.log = noop;
+
+    // Return our tracer impl instead of
+    // the underlying tracer.
+    span.tracer = function() {
+      return obj;
+    };
+
+    return span;
+  };
+
+  obj.startSpan = function(name, spanOptions = {}) {
+    return obj._wrapSpan(obj._tracer.startSpan(name, spanOptions));
+  };
+
+  obj.inject = function(spanOrContext, format, carrier) {
+    obj._tracer.inject(spanOrContext, format, carrier);
+  };
+
+  obj.extract = function(format, carrier) {
+    const span = obj._tracer.extract(format, carrier);
+    return span ? obj._wrapSpan(span) : span;
+  };
+
+  obj.captureFunc = function(name, fn, parentSpan) {
+    const span = obj.startSpan(name, {
+      childOf: parentSpan
+    });
+    try {
+      fn(span);
+      span.finish();
+    } catch (e) {
+      span.setTag(obj.Tags.ERROR, true);
+      span.finish();
+      throw (e);
+    }
+  };
+
+  obj.captureAsync = function(name, fn, parentSpan) {
+    const span = obj.startSpan(name, {
+      childOf: parentSpan
+    });
+    try {
+      fn(span);
+    } catch (e) {
+      span.setTag(obj.Tags.ERROR, true);
+      span.finish();
+      throw (e);
+    }
+  };
+  return obj;
+};

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -3,9 +3,15 @@ const tracerFactory = require('./tracer_factory');
 
 const noop = function() {};
 
-module.exports = function Tracer(agent, pkg, env) {
+const Tags = Object.assign({
+  AUTH0_TENANT: 'auth0.tenant',
+  AUTH0_ENVIRONMENT: 'auth0.environment',
+  AUTH0_CHANNEL: 'auth0.channel'
+}, tracing.Tags);
 
-  const tracer = tracerFactory.create(agent, pkg, env);
+module.exports = function Tracer(agent, pkg, env, tracerImpl) {
+
+  const tracer = tracerImpl ? tracerImpl : tracerFactory.create(agent, pkg, env);
 
   const obj = {
     _tracer: tracer,
@@ -14,18 +20,14 @@ module.exports = function Tracer(agent, pkg, env) {
     FORMAT_TEXT_MAP: tracing.FORMAT_TEXT_MAP
   };
 
-  obj.Tags = Object.assign({
-    AUTH0_TENANT: 'auth0.tenant',
-    AUTH0_ENVIRONMENT: 'auth0.environment',
-    AUTH0_CHANNEL: 'auth0.channel'
-  }, tracing.Tags);
+  obj.Tags = Tags;
 
   // Wrap the native opentracing 'span' object
   // with a reduced API that discourages the use
   // of features we don't want to use yet, while
   // also giving us a place to hook additional
   // functionality.
-  obj._wrapSpan = function(srcSpan) {
+  const wrapSpan = function(srcSpan) {
     const span = Object.create(srcSpan);
 
     // Disable baggage.
@@ -44,8 +46,8 @@ module.exports = function Tracer(agent, pkg, env) {
     return span;
   };
 
-  obj.startSpan = function(name, spanOptions = {}) {
-    return obj._wrapSpan(obj._tracer.startSpan(name, spanOptions));
+  obj.startSpan = function(name, spanOptions) {
+    return wrapSpan(obj._tracer.startSpan(name, spanOptions));
   };
 
   obj.inject = function(spanOrContext, format, carrier) {
@@ -54,9 +56,13 @@ module.exports = function Tracer(agent, pkg, env) {
 
   obj.extract = function(format, carrier) {
     const span = obj._tracer.extract(format, carrier);
-    return span ? obj._wrapSpan(span) : span;
+    return span ? wrapSpan(span) : span;
   };
 
+  // captureFunc is a convenience function for executing a function in a child
+  // span, which is passed to the function as an argument. The created span is
+  // automatically finished regardless of outcome, and is tagged with an error
+  // if an exception is thrown.
   obj.captureFunc = function(name, fn, parentSpan) {
     const span = obj.startSpan(name, {
       childOf: parentSpan
@@ -66,21 +72,9 @@ module.exports = function Tracer(agent, pkg, env) {
       span.finish();
     } catch (e) {
       span.setTag(obj.Tags.ERROR, true);
+      span.setTag(obj.Tags.SAMPLING_PRIORITY, 1);
       span.finish();
-      throw (e);
-    }
-  };
-
-  obj.captureAsync = function(name, fn, parentSpan) {
-    const span = obj.startSpan(name, {
-      childOf: parentSpan
-    });
-    try {
-      fn(span);
-    } catch (e) {
-      span.setTag(obj.Tags.ERROR, true);
-      span.finish();
-      throw (e);
+      throw e;
     }
   };
   return obj;

--- a/lib/tracer_factory.js
+++ b/lib/tracer_factory.js
@@ -1,0 +1,6 @@
+const stubs = require('./stubs');
+
+exports.create = (agent, pkg, env) => {
+  // for now, always return stubs.
+  return stubs.tracer;
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "moment": "^2.18.1",
     "ms": "^2.0.0",
     "node-statsd": "^0.1.1",
+    "opentracing": "^0.14.3",
     "pidusage": "^1.0.4",
     "raven": "^0.10.0",
     "uuid": "^3.0.1",

--- a/test/stubs.test.js
+++ b/test/stubs.test.js
@@ -148,42 +148,42 @@ describe('stubs', function() {
 
   describe('tracer', function() {
     it('should run startSpan without throwing', function() {
-      assert.doesNotThrow(tracer.startSpan, TypeError);
+      assert.doesNotThrow(tracer.startSpan, Error);
     });
 
     it('should run inject without throwing', function() {
-      assert.doesNotThrow(tracer.inject, TypeError);
+      assert.doesNotThrow(tracer.inject, Error);
     });
 
     it('should run extract without throwing', function() {
-      assert.doesNotThrow(tracer.extract, TypeError);
+      assert.doesNotThrow(tracer.extract, Error);
     });
 
     const span = tracer.startSpan('foo');
     describe('tracer', function() {
 
       it('should run finish without throwing', function() {
-        assert.doesNotThrow(span.finish, TypeError);
+        assert.doesNotThrow(span.finish, Error);
       });
 
       it('should run setTag without throwing', function() {
-        assert.doesNotThrow(span.setTag, TypeError);
+        assert.doesNotThrow(span.setTag, Error);
       });
 
       it('shoudl run addTags without throwing', function() {
-        assert.doesNotThrow(span.addTags, TypeError);
+        assert.doesNotThrow(span.addTags, Error);
       });
 
       it('should run tracer without throwing', function() {
-        assert.doesNotThrow(span.tracer, TypeError);
+        assert.doesNotThrow(span.tracer, Error);
       });
 
       it('should run context wihout throwing', function() {
-        assert.doesNotThrow(span.context, TypeError);
+        assert.doesNotThrow(span.context, Error);
       });
 
       it('should run setOperationName without throwing', function() {
-        assert.doesNotThrow(span.setOperationName, TypeError);
+        assert.doesNotThrow(span.setOperationName, Error);
       });
     });
   });

--- a/test/stubs.test.js
+++ b/test/stubs.test.js
@@ -4,6 +4,7 @@ var agent = require('../');
 var errorReporter = agent.errorReporter;
 var metrics = agent.metrics;
 var logger = agent.logger;
+var tracer = agent.tracer;
 
 describe('stubs', function() {
 
@@ -143,6 +144,48 @@ describe('stubs', function() {
       done();
     });
 
+  });
+
+  describe('tracer', function() {
+    it('should run startSpan without throwing', function() {
+      assert.doesNotThrow(tracer.startSpan, TypeError);
+    });
+
+    it('should run inject without throwing', function() {
+      assert.doesNotThrow(tracer.inject, TypeError);
+    });
+
+    it('should run extract without throwing', function() {
+      assert.doesNotThrow(tracer.extract, TypeError);
+    });
+
+    const span = tracer.startSpan('foo');
+    describe('tracer', function() {
+
+      it('should run finish without throwing', function() {
+        assert.doesNotThrow(span.finish, TypeError);
+      });
+
+      it('should run setTag without throwing', function() {
+        assert.doesNotThrow(span.setTag, TypeError);
+      });
+
+      it('shoudl run addTags without throwing', function() {
+        assert.doesNotThrow(span.addTags, TypeError);
+      });
+
+      it('should run tracer without throwing', function() {
+        assert.doesNotThrow(span.tracer, TypeError);
+      });
+
+      it('should run context wihout throwing', function() {
+        assert.doesNotThrow(span.context, TypeError);
+      });
+
+      it('should run setOperationName without throwing', function() {
+        assert.doesNotThrow(span.setOperationName, TypeError);
+      });
+    });
   });
 
 });

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -1,21 +1,12 @@
 const assert = require('assert');
 const opentracing = require('opentracing');
-const $require = require('proxyquire').noPreserveCache();
 
 describe('tracer', function() {
   var $mock;
   var $tracer;
   beforeEach(function() {
-    $tracer = $require('../lib/tracer', {
-      './tracer_factory': {
-        create: function() {
-          $mock = new opentracing.MockTracer();
-          return $mock;
-        }
-      }
-    })({
-      name: 'test'
-    });
+    $mock = new opentracing.MockTracer();
+    $tracer = require('../lib/tracer')({}, {}, {}, $mock);
   });
 
   describe('when wrapped', function() {
@@ -95,21 +86,6 @@ describe('tracer', function() {
       const child = report.firstSpanWithTagValue($tracer.Tags.ERROR, true);
       assert.ok(child);
       assert.equal('child_operation', child.operationName());
-    });
-  });
-
-  describe('captured async functions', function() {
-    it('should automatically create spans', function(done) {
-      const parentSpan = $tracer.startSpan('parent');
-      $tracer.captureAsync('async_child', function(span) {
-        setTimeout(() => {
-          span.finish();
-          parentSpan.finish();
-          const report = $mock.report();
-          assert.equal(2, report.spans.length);
-          done();
-        }, 500);
-      }, parentSpan);
     });
   });
 });

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -1,0 +1,115 @@
+const assert = require('assert');
+const opentracing = require('opentracing');
+const $require = require('proxyquire').noPreserveCache();
+
+describe('tracer', function() {
+  var $mock;
+  var $tracer;
+  beforeEach(function() {
+    $tracer = $require('../lib/tracer', {
+      './tracer_factory': {
+        create: function() {
+          $mock = new opentracing.MockTracer();
+          return $mock;
+        }
+      }
+    })({
+      name: 'test'
+    });
+  });
+
+  describe('when wrapped', function() {
+    it('should contain standard format definitions', function() {
+      assert.equal($tracer.FORMAT_HTTP_HEADERS, opentracing.FORMAT_HTTP_HEADERS);
+      assert.equal($tracer.FORMAT_TEXT_MAP, opentracing.FORMAT_TEXT_MAP);
+    });
+
+    it('should contain standard tags', function() {
+      assert.equal($tracer.Tags.ERROR, opentracing.Tags.ERROR);
+      assert.equal($tracer.Tags.HTTP_METHOD, opentracing.Tags.HTTP_METHOD);
+    });
+
+    it('should define auth0 specific tags', function() {
+      assert.hasOwnProperty($tracer.Tags, 'AUTH0_TENANT');
+      assert.hasOwnProperty($tracer.Tags, 'AUTH0_ENVIRONMENT');
+      assert.hasOwnProperty($tracer.Tags, 'AUTH0_CHANNEL');
+    });
+  });
+
+  describe('wrapped spans', function() {
+    it('should be able to be started and finished', function() {
+      $tracer.startSpan('foo').finish();
+      const report = $mock.report();
+      assert.equal(1, report.spans.length);
+    });
+
+    it('should support tags', function() {
+      const span = $tracer.startSpan('foo');
+      span.setTag('test_tag', 'test_val');
+      span.finish();
+      assert.ok($mock.report().firstSpanWithTagValue('test_tag', 'test_val'));
+    });
+
+    it('should return the wrapped tracer for tracer()', function() {
+      assert.hasOwnProperty(
+        $tracer.startSpan('foo').tracer(), 'AUTH0_TENANT');
+    });
+  });
+
+  describe('captured functions', function() {
+    it('should automatically create spans', function() {
+      const parentSpan = $tracer.startSpan('parent');
+      $tracer.captureFunc('child_operation', function(span) {
+        span.setTag('in_child', true);
+      }, parentSpan);
+      parentSpan.finish();
+      const report = $mock.report();
+      assert.equal(2, report.spans.length);
+      assert.ok(report.firstSpanWithTagValue('in_child', true));
+    });
+
+    it('should support nesting', function() {
+      const rootSpan = $tracer.startSpan('parent');
+      $tracer.captureFunc('child1', function(child1) {
+        $tracer.captureFunc('child2', function(child2) {
+          child2.setTag('in_child_two', true);
+        }, child1);
+      }, rootSpan);
+      rootSpan.finish();
+      const report = $mock.report();
+      assert.equal(3, report.spans.length);
+      assert.ok(report.firstSpanWithTagValue('in_child_two', true));
+    });
+
+    it('should tag failed spans with errors', function() {
+      const parentSpan = $tracer.startSpan('parent');
+      const err = new Error('expected');
+      assert.throws(function() {
+        $tracer.captureFunc('child_operation', function() {
+          throw err;
+        });
+      }, 'expected');
+      parentSpan.finish();
+      const report = $mock.report();
+      assert.equal(2, report.spans.length);
+      const child = report.firstSpanWithTagValue($tracer.Tags.ERROR, true);
+      assert.ok(child);
+      assert.equal('child_operation', child.operationName());
+    });
+  });
+
+  describe('captured async functions', function() {
+    it('should automatically create spans', function(done) {
+      const parentSpan = $tracer.startSpan('parent');
+      $tracer.captureAsync('async_child', function(span) {
+        setTimeout(() => {
+          span.finish();
+          parentSpan.finish();
+          const report = $mock.report();
+          assert.equal(2, report.spans.length);
+          done();
+        }, 500);
+      }, parentSpan);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,10 @@ once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
+opentracing@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.3.tgz#23e3ad029fa66a653926adbe57e834469f8550aa"
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"


### PR DESCRIPTION
For now, this only adds the stub implementation and some helper 'wrappers' so that we can disable functionality we don't plan to use initially and give us a place to hook custom functionality.

Also adds initial tests.