### PR TITLE
Add tracing middleware for hapi16

### DIFF
--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -83,7 +83,8 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
 
   // Add middleware hooks.
   obj.middleware = {
-    express: middleware.express(obj)
+    express: middleware.express(obj),
+    hapi16: middleware.hapi16(obj)
   };
 
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -113,6 +113,7 @@ module.exports = {
       server.ext('onPreResponse', onPreResponse);
 
       server.on('response', finishSpans);
+      next();
     };
 
     register.attributes = {

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -84,14 +84,17 @@ module.exports = {
 
       // set final request status on the primary span.
       req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
-      if (response.isBoom || response.statusCode >= 500) {
+      if ((response.isBoom && response.output.statusCode >= 500) || response.statusCode >= 500) {
         req.a0trace.span.setTag(tracer.Tags.ERROR, true);
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
-      if (response) {
-        const responseHeaders = {};
-        tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      // Inject headers for the request span into the response, for debugging.
+      const responseHeaders = {};
+      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      if (response.isBoom) {
+        Object.keys(responseHeaders).forEach((key) => { response.output.headers[key] = responseHeaders[key]; });
+      } else {
         Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
       }
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -90,7 +90,7 @@ module.exports = {
       }
 
       const responseHeaders = {};
-      tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
       Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
 
       // will be automatically finished by the response event.

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -9,7 +9,7 @@ function createRequestSpan(tracer, req) {
   const span = tracer.startSpan(name, { childOf: wireCtx });
   span.setTag(tracer.Tags.HTTP_METHOD, req.method);
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-  span.setTag(tracer.Tags.HTTP_URL, req.url);
+  span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
   return span;
 };
 
@@ -47,8 +47,9 @@ module.exports = {
   hapi16: function(tracer) {
 
     const startSpans = (req) => {
+      const span = createRequestSpan(tracer, req);
       return {
-        span: createRequestSpan(tracer, req),
+        span: span,
         tracer: tracer
       };
     };
@@ -88,6 +89,10 @@ module.exports = {
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
+      const responseHeaders = {};
+      tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
       reply.continue();
@@ -97,7 +102,7 @@ module.exports = {
       if (req && req.a0trace) {
         for (const key of Object.keys(req.a0trace)) {
           const span = req.a0trace[key];
-          if (span && span.hasOwnProperty('finish')) {
+          if (span && span.finish) {
             span.finish();
           }
         }
@@ -105,8 +110,8 @@ module.exports = {
     };
 
     const register = function(server, options, next) {
-      // Create a new request span for each incoming request.
       server.decorate('request', 'a0trace',  startSpans, {apply: true});
+
       server.ext('onPreAuth', onPreAuth);
       server.ext('onPostAuth', onPostAuth);
       server.ext('onPreHandler', onPreHandler);

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -9,7 +9,7 @@ function createRequestSpan(tracer, req) {
   const span = tracer.startSpan(name, { childOf: wireCtx });
   span.setTag(tracer.Tags.HTTP_METHOD, req.method);
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-  span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
+  span.setTag(tracer.Tags.HTTP_URL, req.url.href ? req.url.href : req.url);
   return span;
 }
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -89,9 +89,11 @@ module.exports = {
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
-      const responseHeaders = {};
-      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
-      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+      if (response) {
+        const responseHeaders = {};
+        tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+        Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+      }
 
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -1,17 +1,22 @@
 const onFinished = require('on-finished');
 const url = require('url');
 
+
+// createRequestSpan creates a new Span for an incoming request.
+function createRequestSpan(tracer, req) {
+  const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
+  const name = req.path ? req.path : url.parse(req.url).pathname;
+  const span = tracer.startSpan(name, { childOf: wireCtx });
+  span.setTag(tracer.Tags.HTTP_METHOD, req.method);
+  span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
+  span.setTag(tracer.Tags.HTTP_URL, req.url);
+  return span;
+};
+
 module.exports = {
   express: function(tracer) {
     return (req, res, next) => {
-      const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
-      const pathname = url.parse(req.url).pathname;
-      const span = tracer.startSpan(pathname, {
-        childOf: wireCtx
-      });
-      span.setTag(tracer.Tags.HTTP_METHOD, req.method);
-      span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-      span.setTag(tracer.Tags.HTTP_URL, req.url);
+      const span = createRequestSpan(tracer, req);
 
       // Include the trace context in response headers, to facilitate debugging.
       const responseHeaders = {};
@@ -37,5 +42,83 @@ module.exports = {
 
       next();
     };
+  },
+
+  hapi16: function(tracer) {
+
+    const startSpans = (req) => {
+      return {
+        span: createRequestSpan(tracer, req),
+        tracer: tracer
+      };
+    };
+
+    const onPreAuth = (req, reply) => {
+      req.a0trace.auth = tracer.startSpan('auth', { childOf: req.a0trace.span });
+      reply.continue();
+    };
+
+    const onPostAuth = (req, reply) => {
+      req.a0trace.auth.setTag('auth.isAuthenticated', req.auth.isAuthenticated);
+      req.a0trace.auth.setTag('auth.mode', req.auth.mode);
+      req.a0trace.auth.finish();
+      req.a0trace.auth = null;
+      reply.continue();
+    };
+
+    const onPreHandler = (req, reply) => {
+      req.a0trace.handler = tracer.startSpan('handler', { childOf: req.a0trace.span });
+      reply.continue();
+    }
+
+    const onPreResponse = (req, reply) => {
+      // We may not have an active handler span, since it's possible
+      // to skip directly to the response step if routing fails.
+      // See: https://hapijs.com/api/16.6.2#request-lifecycle
+      if (req.a0trace.handler) {
+        req.a0trace.handler.finish();
+        req.a0trace.handler = null;
+      }
+      const response = req.response;
+
+      // set final request status on the primary span.
+      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
+      if (response.isBoom || response.statusCode >= 500) {
+        req.a0trace.span.setTag(tracer.Tags.ERROR, true);
+        req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
+      }
+
+      // will be automatically finished by the response event.
+      req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
+      reply.continue();
+    }
+
+    const finishSpans = (req) => {
+      if (req && req.a0trace) {
+        for (const key of Object.keys(req.a0trace)) {
+          const span = req.a0trace[key];
+          if (span) {
+            span.finish();
+          }
+        }
+      }
+    };
+
+    const register = function(server, options, next) {
+      // Create a new request span for each incoming request.
+      server.decorate('request', 'a0trace',  startSpans, {apply: true});
+      server.ext('onPreAuth', onPreAuth);
+      server.ext('onPostAuth', onPostAuth);
+      server.ext('onPreHandler', onPreHandler);
+      server.ext('onPreResponse', onPreResponse);
+
+      server.on('response', finishSpans);
+    };
+
+    register.attributes = {
+      name: 'a0trace'
+    }
+
+    return register;
   }
 };

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -11,7 +11,7 @@ function createRequestSpan(tracer, req) {
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
   span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
   return span;
-};
+}
 
 module.exports = {
   express: function(tracer) {
@@ -70,7 +70,7 @@ module.exports = {
     const onPreHandler = (req, reply) => {
       req.a0trace.handler = tracer.startSpan('handler', { childOf: req.a0trace.span });
       reply.continue();
-    }
+    };
 
     const onPreResponse = (req, reply) => {
       // We may not have an active handler span, since it's possible
@@ -81,10 +81,11 @@ module.exports = {
         req.a0trace.handler = null;
       }
       const response = req.response;
+      const statusCode = response.isBoom ? response.output.statusCode : response.statusCode;
 
       // set final request status on the primary span.
-      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
-      if ((response.isBoom && response.output.statusCode >= 500) || response.statusCode >= 500) {
+      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, statusCode);
+      if (statusCode >= 500) {
         req.a0trace.span.setTag(tracer.Tags.ERROR, true);
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
@@ -101,7 +102,7 @@ module.exports = {
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
       reply.continue();
-    }
+    };
 
     const finishSpans = (req) => {
       if (req && req.a0trace) {
@@ -128,7 +129,7 @@ module.exports = {
 
     register.attributes = {
       name: 'a0trace'
-    }
+    };
 
     return register;
   }

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -97,7 +97,7 @@ module.exports = {
       if (req && req.a0trace) {
         for (const key of Object.keys(req.a0trace)) {
           const span = req.a0trace[key];
-          if (span) {
+          if (span && span.hasOwnProperty('finish')) {
             span.finish();
           }
         }

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -255,7 +255,7 @@ describe('tracer using jaeger-client', function() {
   });
 });
 
-describe.only('tracer hapi16 middleware', function() {
+describe('tracer hapi16 middleware', function() {
   // We expect 4 spans:
   //  - request (top level span)
   //  - auth


### PR DESCRIPTION
This PR adds basic tracing middleware for hapi16 along with tests, which creates spans automatically for the request as well as for each extension point in the request lifecycle.

Rather than using the plugin builder approach, this exposes a version specific 'hapi16' property on the tracer 'middleware' object, rather than using the plugin-builder approach to version detection. This makes the auth0-library slightly inconsistent, but I generally prefer explicitness.

There is likely code here that will be re-used for the hapi17 version, but factoring out that common code will be part of the hapi17 PR.