### PR TITLE
Removes Node v4 from project tests (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
 install:


### PR DESCRIPTION
We'll run LTS versions only