### PR TITLE
tracing: Add the ability to 'wrap' existing express middleware in a child span.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,10 @@
     "no-console": [
      "error",
      { "allow": ["debug", "info", "warn", "error"] }
+    ],
+    "no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_" }
     ]
   }
 }

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -83,7 +83,8 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
 
   // Add middleware hooks.
   obj.middleware = {
-    express: middleware.express(obj)
+    express: middleware.express(obj),
+    hapi16: middleware.hapi16(obj)
   };
 
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -15,7 +15,7 @@ function createRequestSpan(tracer, req) {
 
 module.exports = {
   express: function(tracer) {
-    return (req, res, next) => {
+    const mw = (req, res, next) => {
       const span = createRequestSpan(tracer, req);
 
       // Include the trace context in response headers, to facilitate debugging.
@@ -42,6 +42,40 @@ module.exports = {
 
       next();
     };
+
+    // Allow wrapping of existing middlware.
+    mw.wrap = (name, middlware) {
+      const wrapped = (req, res, next) => {
+        const parentCtx = req.a0trace ? req.a0trace.span : undefined;
+        const span = agent.tracer.startSpan(name, { childOf: parentCtx });
+        // not all implementations support idempotent finish.
+        var finished = false;
+        const finish = () => {
+          if (!finished) {
+            span.finish();
+          }
+        };
+
+        const wrappedNext = function() {
+          finish();
+          return next.apply(null, arguments);
+        };
+
+        onFinished(res, (err, res) => {
+          finish();
+        });
+
+        try {
+          mw(req, res, wrappedNext);
+        } catch (err) {
+          span.setTag(agent.tracer.Tags.ERROR, true);
+          finish();
+        }
+      }
+      return wrapped;
+    };
+
+    return mw;
   },
 
   hapi16: function(tracer) {

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -113,6 +113,7 @@ module.exports = {
       server.ext('onPreResponse', onPreResponse);
 
       server.on('response', finishSpans);
+      next();
     };
 
     register.attributes = {

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -76,6 +76,37 @@ module.exports = {
       return wrapped;
     };
 
+    mw.wrapErr = (name, target) => {
+        const parentCtx = req.a0trace ? req.a0trace.span : undefined;
+        const span = tracer.startSpan(name, { childOf: parentCtx });
+        // not all implementations support idempotent finish.
+        var finished = false;
+        const finish = () => {
+          if (!finished) {
+            finished = true;
+            span.finish();
+          }
+        };
+
+        const wrappedNext = function() {
+          finish();
+          return next.apply(null, arguments);
+        };
+
+        onFinished(res, (err, res) => {
+          finish();
+        });
+
+        try {
+          target(err, req, res, wrappedNext);
+        } catch (err) {
+          span.setTag(tracer.Tags.ERROR, true);
+          finish();
+        }
+      }
+      return wrapped;
+    };
+
     return mw;
   },
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -84,14 +84,17 @@ module.exports = {
 
       // set final request status on the primary span.
       req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
-      if (response.isBoom || response.statusCode >= 500) {
+      if ((response.isBoom && response.output.statusCode >= 500) || response.statusCode >= 500) {
         req.a0trace.span.setTag(tracer.Tags.ERROR, true);
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
-      if (response) {
-        const responseHeaders = {};
-        tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      // Inject headers for the request span into the response, for debugging.
+      const responseHeaders = {};
+      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      if (response.isBoom) {
+        Object.keys(responseHeaders).forEach((key) => { response.output.headers[key] = responseHeaders[key]; });
+      } else {
         Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
       }
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -44,7 +44,7 @@ module.exports = {
     };
 
     // Allow wrapping of existing middlware.
-    mw.wrap = (name, middlware) => {
+    mw.wrap = (name, target) => {
       const wrapped = (req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
         const span = tracer.startSpan(name, { childOf: parentCtx });
@@ -67,7 +67,7 @@ module.exports = {
         });
 
         try {
-          mw(req, res, wrappedNext);
+          target(req, res, wrappedNext);
         } catch (err) {
           span.setTag(tracer.Tags.ERROR, true);
           finish();

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -90,7 +90,7 @@ module.exports = {
       }
 
       const responseHeaders = {};
-      tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
       Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
 
       // will be automatically finished by the response event.

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -76,7 +76,8 @@ module.exports = {
       return wrapped;
     };
 
-    mw.wrapErr = (name, target) => {
+    mw.wrapErr = (name, target) => 
+      const wrapped = (err, req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
         const span = tracer.startSpan(name, { childOf: parentCtx });
         // not all implementations support idempotent finish.

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -9,7 +9,7 @@ function createRequestSpan(tracer, req) {
   const span = tracer.startSpan(name, { childOf: wireCtx });
   span.setTag(tracer.Tags.HTTP_METHOD, req.method);
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-  span.setTag(tracer.Tags.HTTP_URL, req.url);
+  span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
   return span;
 };
 
@@ -47,8 +47,9 @@ module.exports = {
   hapi16: function(tracer) {
 
     const startSpans = (req) => {
+      const span = createRequestSpan(tracer, req);
       return {
-        span: createRequestSpan(tracer, req),
+        span: span,
         tracer: tracer
       };
     };
@@ -88,6 +89,10 @@ module.exports = {
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
+      const responseHeaders = {};
+      tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
       reply.continue();
@@ -97,7 +102,7 @@ module.exports = {
       if (req && req.a0trace) {
         for (const key of Object.keys(req.a0trace)) {
           const span = req.a0trace[key];
-          if (span && span.hasOwnProperty('finish')) {
+          if (span && span.finish) {
             span.finish();
           }
         }
@@ -105,8 +110,8 @@ module.exports = {
     };
 
     const register = function(server, options, next) {
-      // Create a new request span for each incoming request.
       server.decorate('request', 'a0trace',  startSpans, {apply: true});
+
       server.ext('onPreAuth', onPreAuth);
       server.ext('onPostAuth', onPostAuth);
       server.ext('onPreHandler', onPreHandler);

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -9,7 +9,7 @@ function createRequestSpan(tracer, req) {
   const span = tracer.startSpan(name, { childOf: wireCtx });
   span.setTag(tracer.Tags.HTTP_METHOD, req.method);
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-  span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
+  span.setTag(tracer.Tags.HTTP_URL, req.url.href ? req.url.href : req.url);
   return span;
 }
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -89,9 +89,11 @@ module.exports = {
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
 
-      const responseHeaders = {};
-      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
-      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+      if (response) {
+        const responseHeaders = {};
+        tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+        Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+      }
 
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -48,63 +48,50 @@ module.exports = {
       const wrapped = (req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
         const span = tracer.startSpan(name, { childOf: parentCtx });
-        // not all implementations support idempotent finish.
+
+        // There are 3 ways that a middleware can complete:
+        //  - calling next() (optionally with a value)
+        //  - Throwing an exception
+        //  - sending (and finishing) a response.
+        //  We need to call span.finish() in each of these cases, but
+        //  there is nothing in the opentracing spec that defines the
+        //  behavior on multiple calls to finish.
+
         var finished = false;
-        const finish = () => {
+        const finish = (tags) => {
           if (!finished) {
             finished = true;
+            if (tags) {
+              span.addTags(tags);
+            }
             span.finish();
           }
         };
 
         const wrappedNext = function() {
-          finish();
+          finish({'finished.by': 'next'});
           return next.apply(null, arguments);
         };
 
-        onFinished(res, (err, res) => {
-          finish();
+        onFinished(res, (err, _res) => {
+          const tags = {'finished.by': 'response'};
+          if (err) {
+            tags[tracer.Tags.ERROR] = true;
+            tags[tracer.Tags.SAMPLING_PRIORITY] = 1;
+          }
+          finish(tags);
         });
 
         try {
           target(req, res, wrappedNext);
         } catch (err) {
-          span.setTag(tracer.Tags.ERROR, true);
-          finish();
+          const tags = {'finished.by': 'error'};
+          tags[tracer.Tags.ERROR] = true;
+          tags[tracer.Tags.SAMPLING_PRIORITY] = 1;
+          finish(tags);
+          throw err;
         }
-      }
-      return wrapped;
-    };
-
-    mw.wrapErr = (name, target) => {
-      const wrapped = (err, req, res, next) => {
-        const parentCtx = req.a0trace ? req.a0trace.span : undefined;
-        const span = tracer.startSpan(name, { childOf: parentCtx });
-        // not all implementations support idempotent finish.
-        var finished = false;
-        const finish = () => {
-          if (!finished) {
-            finished = true;
-            span.finish();
-          }
-        };
-
-        const wrappedNext = function() {
-          finish();
-          return next.apply(null, arguments);
-        };
-
-        onFinished(res, (err, res) => {
-          finish();
-        });
-
-        try {
-          target(err, req, res, wrappedNext);
-        } catch (err) {
-          span.setTag(tracer.Tags.ERROR, true);
-          finish();
-        }
-      }
+      };
       return wrapped;
     };
 

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -1,17 +1,22 @@
 const onFinished = require('on-finished');
 const url = require('url');
 
+
+// createRequestSpan creates a new Span for an incoming request.
+function createRequestSpan(tracer, req) {
+  const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
+  const name = req.path ? req.path : url.parse(req.url).pathname;
+  const span = tracer.startSpan(name, { childOf: wireCtx });
+  span.setTag(tracer.Tags.HTTP_METHOD, req.method);
+  span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
+  span.setTag(tracer.Tags.HTTP_URL, req.url);
+  return span;
+};
+
 module.exports = {
   express: function(tracer) {
     return (req, res, next) => {
-      const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
-      const pathname = url.parse(req.url).pathname;
-      const span = tracer.startSpan(pathname, {
-        childOf: wireCtx
-      });
-      span.setTag(tracer.Tags.HTTP_METHOD, req.method);
-      span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
-      span.setTag(tracer.Tags.HTTP_URL, req.url);
+      const span = createRequestSpan(tracer, req);
 
       // Include the trace context in response headers, to facilitate debugging.
       const responseHeaders = {};
@@ -37,5 +42,83 @@ module.exports = {
 
       next();
     };
+  },
+
+  hapi16: function(tracer) {
+
+    const startSpans = (req) => {
+      return {
+        span: createRequestSpan(tracer, req),
+        tracer: tracer
+      };
+    };
+
+    const onPreAuth = (req, reply) => {
+      req.a0trace.auth = tracer.startSpan('auth', { childOf: req.a0trace.span });
+      reply.continue();
+    };
+
+    const onPostAuth = (req, reply) => {
+      req.a0trace.auth.setTag('auth.isAuthenticated', req.auth.isAuthenticated);
+      req.a0trace.auth.setTag('auth.mode', req.auth.mode);
+      req.a0trace.auth.finish();
+      req.a0trace.auth = null;
+      reply.continue();
+    };
+
+    const onPreHandler = (req, reply) => {
+      req.a0trace.handler = tracer.startSpan('handler', { childOf: req.a0trace.span });
+      reply.continue();
+    }
+
+    const onPreResponse = (req, reply) => {
+      // We may not have an active handler span, since it's possible
+      // to skip directly to the response step if routing fails.
+      // See: https://hapijs.com/api/16.6.2#request-lifecycle
+      if (req.a0trace.handler) {
+        req.a0trace.handler.finish();
+        req.a0trace.handler = null;
+      }
+      const response = req.response;
+
+      // set final request status on the primary span.
+      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
+      if (response.isBoom || response.statusCode >= 500) {
+        req.a0trace.span.setTag(tracer.Tags.ERROR, true);
+        req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
+      }
+
+      // will be automatically finished by the response event.
+      req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
+      reply.continue();
+    }
+
+    const finishSpans = (req) => {
+      if (req && req.a0trace) {
+        for (const key of Object.keys(req.a0trace)) {
+          const span = req.a0trace[key];
+          if (span) {
+            span.finish();
+          }
+        }
+      }
+    };
+
+    const register = function(server, options, next) {
+      // Create a new request span for each incoming request.
+      server.decorate('request', 'a0trace',  startSpans, {apply: true});
+      server.ext('onPreAuth', onPreAuth);
+      server.ext('onPostAuth', onPostAuth);
+      server.ext('onPreHandler', onPreHandler);
+      server.ext('onPreResponse', onPreResponse);
+
+      server.on('response', finishSpans);
+    };
+
+    register.attributes = {
+      name: 'a0trace'
+    }
+
+    return register;
   }
 };

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -76,7 +76,7 @@ module.exports = {
       return wrapped;
     };
 
-    mw.wrapErr = (name, target) => 
+    mw.wrapErr = (name, target) => {
       const wrapped = (err, req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
         const span = tracer.startSpan(name, { childOf: parentCtx });

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -11,7 +11,7 @@ function createRequestSpan(tracer, req) {
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
   span.setTag(tracer.Tags.HTTP_URL, req.href ? req.href : req.url);
   return span;
-};
+}
 
 module.exports = {
   express: function(tracer) {
@@ -70,7 +70,7 @@ module.exports = {
     const onPreHandler = (req, reply) => {
       req.a0trace.handler = tracer.startSpan('handler', { childOf: req.a0trace.span });
       reply.continue();
-    }
+    };
 
     const onPreResponse = (req, reply) => {
       // We may not have an active handler span, since it's possible
@@ -81,10 +81,11 @@ module.exports = {
         req.a0trace.handler = null;
       }
       const response = req.response;
+      const statusCode = response.isBoom ? response.output.statusCode : response.statusCode;
 
       // set final request status on the primary span.
-      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, response.statusCode);
-      if ((response.isBoom && response.output.statusCode >= 500) || response.statusCode >= 500) {
+      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, statusCode);
+      if (statusCode >= 500) {
         req.a0trace.span.setTag(tracer.Tags.ERROR, true);
         req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
       }
@@ -101,7 +102,7 @@ module.exports = {
       // will be automatically finished by the response event.
       req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
       reply.continue();
-    }
+    };
 
     const finishSpans = (req) => {
       if (req && req.a0trace) {
@@ -128,7 +129,7 @@ module.exports = {
 
     register.attributes = {
       name: 'a0trace'
-    }
+    };
 
     return register;
   }

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -44,7 +44,7 @@ module.exports = {
     };
 
     // Allow wrapping of existing middlware.
-    mw.wrap = (name, middlware) {
+    mw.wrap = (name, middlware) => {
       const wrapped = (req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
         const span = agent.tracer.startSpan(name, { childOf: parentCtx });

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -97,7 +97,7 @@ module.exports = {
       if (req && req.a0trace) {
         for (const key of Object.keys(req.a0trace)) {
           const span = req.a0trace[key];
-          if (span) {
+          if (span && span.hasOwnProperty('finish')) {
             span.finish();
           }
         }

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -52,6 +52,7 @@ module.exports = {
         var finished = false;
         const finish = () => {
           if (!finished) {
+            finished = true;
             span.finish();
           }
         };

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -47,7 +47,7 @@ module.exports = {
     mw.wrap = (name, middlware) => {
       const wrapped = (req, res, next) => {
         const parentCtx = req.a0trace ? req.a0trace.span : undefined;
-        const span = agent.tracer.startSpan(name, { childOf: parentCtx });
+        const span = tracer.startSpan(name, { childOf: parentCtx });
         // not all implementations support idempotent finish.
         var finished = false;
         const finish = () => {
@@ -68,7 +68,7 @@ module.exports = {
         try {
           mw(req, res, wrappedNext);
         } catch (err) {
-          span.setTag(agent.tracer.Tags.ERROR, true);
+          span.setTag(tracer.Tags.ERROR, true);
           finish();
         }
       }

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -320,7 +320,7 @@ describe('tracer hapi16 middleware', function() {
       server.stop(done);
     });
 
-    it('should create new child spans', function(done) {
+    it('should create new child spans', function() {
       const req = { method: 'GET', url: `${server.info.uri}/success` };
       server.inject(req)
         .then(res => {
@@ -330,14 +330,10 @@ describe('tracer hapi16 middleware', function() {
           const reqSpan = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 200);
           assert.ok(reqSpan);
           assert.equal('/success', reqSpan.operationName());
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 
-    it('should set error tags on failure', function(done) {
+    it('should set error tags on failure', function() {
       const req = { method: 'GET', url: `${server.info.uri}/failure` };
       server.inject(req)
         .then(res => {
@@ -347,16 +343,12 @@ describe('tracer hapi16 middleware', function() {
           const reqSpan = report.firstSpanWithTagValue(tracer.Tags.ERROR, true);
           assert.ok(reqSpan);
           assert.equal('/failure', reqSpan.operationName());
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 
-    it('should set error tags on exceptions', function(done) {
+    it('should set error tags on exceptions', function() {
       const req = { method: 'GET', url: `${server.info.uri}/error` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(500, res.statusCode);
           const report = mock.report();
@@ -364,48 +356,36 @@ describe('tracer hapi16 middleware', function() {
           const reqSpan = report.firstSpanWithTagValue(tracer.Tags.ERROR, true);
           assert.ok(reqSpan);
           assert.equal('/error', reqSpan.operationName());
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 
-    it('should include span headers in the response when successful', function(done) {
+    it('should include span headers in the response when successful', function() {
       const req = { method: 'GET', url: `${server.info.uri}/success` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(200, res.statusCode);
           const report = mock.report();
           const child = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 200);
           assert.ok(child);
           assert.equal(child.uuid(), res.headers['x-span-id']);
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 
-    it('should include span headers in the response for failures', function(done) {
+    it('should include span headers in the response for failures', function() {
       const req = { method: 'GET', url: `${server.info.uri}/error` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(500, res.statusCode);
           const report = mock.report();
           const child = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 500);
           assert.ok(child);
           assert.equal(child.uuid(), res.headers['x-span-id']);
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 
-    it('should make the created span available to handlers', function(done) {
+    it('should make the created span available to handlers', function() {
       const req = { method: 'GET', url: `${server.info.uri}/moreinfo` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(200, res.statusCode);
           const report = mock.report();
@@ -413,10 +393,6 @@ describe('tracer hapi16 middleware', function() {
           const reqSpan = report.firstSpanWithTagValue('more_info', 'here');
           assert.ok(reqSpan);
           assert.equal('/moreinfo', reqSpan.operationName());
-          done();
-        })
-        .catch(err => {
-          done(err);
         });
     });
 

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -307,8 +307,8 @@ describe('tracer hapi16 middleware', function() {
       });
       server.register(tracer.middleware.hapi16, err => {
         if (err) { done(err); }
+        server.start(done);
       });
-      server.start(done);
     });
 
     afterEach(done => {

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -255,7 +255,7 @@ describe('tracer using jaeger-client', function() {
   });
 });
 
-describe.only('tracer hapi16 middleware', function() {
+describe('tracer hapi16 middleware', function() {
   // We expect 4 spans:
   //  - request (top level span)
   //  - auth

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -273,7 +273,7 @@ describe('tracer hapi16 middleware', function() {
       };
       mock.extract = sinon.fake();
       tracer = require('../lib/tracer')({}, {}, {}, mock);
-      
+
       server = new hapi16.Server();
       server.connection({ port: 9999 });
       server.route({

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -419,5 +419,6 @@ describe('tracer hapi16 middleware', function() {
           done(err);
         });
     });
+
   });
 });

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -308,12 +308,7 @@ describe('tracer hapi16 middleware', function() {
       server.register(tracer.middleware.hapi16, err => {
         if (err) { done(err); }
       });
-      server.start(err => {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      server.start(done);
     });
 
     afterEach(done => {
@@ -322,7 +317,7 @@ describe('tracer hapi16 middleware', function() {
 
     it('should create new child spans', function() {
       const req = { method: 'GET', url: `${server.info.uri}/success` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(200, res.statusCode);
           const report = mock.report();
@@ -335,7 +330,7 @@ describe('tracer hapi16 middleware', function() {
 
     it('should set error tags on failure', function() {
       const req = { method: 'GET', url: `${server.info.uri}/failure` };
-      server.inject(req)
+      return server.inject(req)
         .then(res => {
           assert.equal(500, res.statusCode);
           const report = mock.report();

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -125,8 +125,8 @@ describe('tracer express middleware', function() {
       });
     });
 
-    it('should create new child spans', function(done) {
-      request(app)
+    it('should create new child spans', function() {
+      return request(app)
         .get('/success')
         .expect(200)
         .expect(function() {
@@ -137,27 +137,22 @@ describe('tracer express middleware', function() {
           assert.equal('/success', child.operationName());
           assert.equal('GET', child.tags()[$tracer.Tags.HTTP_METHOD]);
           assert.equal($tracer.Tags.SPAN_KIND_RPC_SERVER, child.tags()[$tracer.Tags.SPAN_KIND]);
-        })
-        .then(() =>  { done(); })
-        .catch(err => { done(err); });
+        });
     });
 
-    it('should make the created span available to the request', function(done) {
-      request(app)
+    it('should make the created span available to the request', function() {
+      return request(app)
         .get('/moreinfo')
         .expect(200)
         .expect(function() {
           const report = $mock.report();
           assert.equal(1, report.spans.length);
           assert.ok(report.firstSpanWithTagValue('moreinfo', 'here'));
-        })
-        .then(() => { done(); })
-        .catch(err => { done(err); });
-
+        });
     });
 
-    it('should set error tags on status codes >= 500', function(done) {
-      request(app)
+    it('should set error tags on status codes >= 500', function() {
+      return request(app)
         .get('/error')
         .expect(500)
         .expect(function() {
@@ -169,14 +164,11 @@ describe('tracer express middleware', function() {
           assert.equal('GET', child.tags()[$tracer.Tags.HTTP_METHOD]);
           assert.equal($tracer.Tags.SPAN_KIND_RPC_SERVER, child.tags()[$tracer.Tags.SPAN_KIND]);
           assert.ok(child.tags()[$tracer.Tags.ERROR]);
-        })
-        .then(() => { done(); })
-        .catch(err => { done(err); });
-        
+        });
     });
 
-    it('should set error tags on exceptions', function(done) {
-      request(app)
+    it('should set error tags on exceptions', function() {
+      return request(app)
         .get('/exception')
         .expect(500)
         .expect(function() {
@@ -188,13 +180,11 @@ describe('tracer express middleware', function() {
           assert.equal('GET', child.tags()[$tracer.Tags.HTTP_METHOD]);
           assert.equal($tracer.Tags.SPAN_KIND_RPC_SERVER, child.tags()[$tracer.Tags.SPAN_KIND]);
           assert.ok(child.tags()[$tracer.Tags.ERROR]);
-        })
-        .then(() => { done(); })
-        .catch(err => { done(err); });
+        });
     });
 
-    it('should include span headers in the response', function(done) {
-      request(app)
+    it('should include span headers in the response', function() {
+      return request(app)
         .get('/success')
         .expect(200)
         .expect(function(res) {
@@ -203,9 +193,82 @@ describe('tracer express middleware', function() {
           const child = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
           assert.ok(child);
           assert.equal(child.uuid(), res.get('x-span-id'));
-        })
-        .then(() => { done(); })
-        .catch(err => { done(err); });
+        });
+    });
+  });
+
+  describe('wrapping existing middleware', function() {
+    var $mock;
+    var $tracer;
+    var app;
+    beforeEach(function() {
+      $mock = new opentracing.MockTracer();
+      // the mock tracer doesn't native support extract/inject.
+      $mock.inject = function(span, format, carrier) {
+        carrier['x-span-id'] = span.uuid();
+      };
+      $mock.extract = sinon.fake();
+      $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+      app = express();
+      app.use($tracer.middleware.express);
+    });
+
+    it('should create and finish spans on next()', function() {
+      app.use($tracer.middleware.express.wrap('simple', function(req, res, next) {
+        next();
+      }));
+      app.get('/', function(req, res) {
+        res.send('ok');
+      });
+      return request(app)
+        .get('/')
+        .expect(200)
+        .expect(function() {
+          const report = $mock.report();
+          assert.equal(2, report.spans.length);
+          const child = report.firstSpanWithTagValue('finished.by', 'next');
+          assert.ok(child);
+          assert.equal('simple', child.operationName());
+        });
+    });
+
+    it('should create and finish spans on response', function() {
+      app.use($tracer.middleware.express.wrap('response', function(req, res, next) {
+        res.status(401).send('go away');
+      }));
+      app.get('/', function(req, res) {
+        res.send('ok');
+      });
+      return request(app)
+        .get('/')
+        .expect(401)
+        .expect(function() {
+          const report = $mock.report();
+          assert.equal(2, report.spans.length);
+          const child = report.firstSpanWithTagValue('finished.by', 'response');
+          assert.ok(child);
+          assert.equal('response', child.operationName());
+        });
+    });
+
+    it('should create and finish spans on errors', function() {
+      app.use($tracer.middleware.express.wrap('error', function(req, res, next) {
+        throw new Error('middlware error');
+      }));
+      app.get('/', function(req, res) {
+        res.send('ok');
+      });
+      return request(app)
+        .get('/')
+        .expect(500)
+        .expect(function() {
+          const report = $mock.report();
+          assert.equal(2, report.spans.length);
+          const child = report.firstSpanWithTagValue('finished.by', 'error');
+          assert.ok(child);
+          assert.equal('error', child.operationName());
+          assert.ok(child.tags()[$tracer.Tags.ERROR]);
+        });
     });
   });
 });


### PR DESCRIPTION
This is a convenience function for quickly getting visibility into the execution of existing express middleware.

Also included in this PR
 - Fix existing express tests to return promises
 - Suppress printing stack traces on exceptions caught by express.
 - Small change to eslintrc to permit unused arguments prefixed with underscore.