### PR TITLE
Tracing: Add support for non-HTTP propagation using the AUTH0_BINARY format

### DIFF
--- a/lib/trace_context.proto
+++ b/lib/trace_context.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package auth0.instrumentation;
+
+// A SpanContext message contains the protocol buffer
+// representation of the information needed to propagate
+// a span.
+// This message is useful for passing trace context between
+// services that used protocol buffers to communicate.
+message SpanContext {
+  map<string, string> span_context_map = 1;
+};

--- a/lib/trace_context.proto
+++ b/lib/trace_context.proto
@@ -4,9 +4,11 @@ package auth0.instrumentation;
 
 // A SpanContext message contains the protocol buffer
 // representation of the information needed to propagate
-// a span.
-// This message is useful for passing trace context between
-// services that used protocol buffers to communicate.
+// an opentracing span.
+// A serialized version of this message is used as the
+// carrier for the AUTH0_BINARY format.
 message SpanContext {
+  // span_context_map is an opaque set of key/value pairs as
+  // returned by the 'Text Map' opentracing format.
   map<string, string> span_context_map = 1;
 };

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -9,7 +9,7 @@ const constants = require('./constants');
 const noop = function() {};
 
 const protoRoot = new protobuf.Root();
-protoRoot.loadSync(path.join(__dirname, 'trace_context.proto'))
+protoRoot.loadSync(path.join(__dirname, 'trace_context.proto'));
 const SpanContext = protoRoot.lookupType('auth0.instrumentation.SpanContext');
 
 const Tags = Object.assign({
@@ -61,6 +61,14 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
     return wrapSpan(obj._tracer.startSpan(name, spanOptions));
   };
 
+  // Inject the context required to propagate `spanOrContext` using
+  // the specified format and carrier.
+  // (see: https://github.com/opentracing/specification/blob/master/specification.md )
+  // When using the AUTHO_BINARY format, `carrier` should be a function
+  // that will receive the opaque context payload.
+  // e.g.
+  // var context;
+  // tracer.inject(span, tracer.FORMAT_AUTH0_BINARY, (ctx) => { context = ctx });
   obj.inject = function(spanOrContext, format, carrier) {
     if (format === obj.FORMAT_AUTH0_BINARY) {
       const textCarrier = {};
@@ -68,13 +76,18 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
       const carrierMsg = SpanContext.create({
         spanContextMap: textCarrier
       });
-      console.log('carrier message', carrierMsg);
       const encoded = SpanContext.encode(carrierMsg).finish();
-      return carrier(encoded);
+      try {
+        return carrier(encoded);
+      } catch (err) {
+        // ignore failures to propagate
+      }
+
     }
     obj._tracer.inject(spanOrContext, format, carrier);
   };
 
+  // Extract span context from a carrier, using the specified format.
   obj.extract = function(format, carrier) {
     if (format === obj.FORMAT_AUTH0_BINARY) {
       // Carrier should be a buffer containing a serialized
@@ -84,8 +97,7 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
         const decoded = SpanContext.decode(carrier);
         return obj.extract(obj.FORMAT_TEXT_MAP, decoded.spanContextMap);
       } catch (e) {
-        console.log('failed to decode proto message', e);
-        //obj._logger.debug('failed to decode proto message', err);
+        // ignore decode failures. 
         return null;
       }
     }

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -82,7 +82,6 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
       } catch (err) {
         // ignore failures to propagate
       }
-
     }
     obj._tracer.inject(spanOrContext, format, carrier);
   };
@@ -97,7 +96,7 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
         const decoded = SpanContext.decode(carrier);
         return obj.extract(obj.FORMAT_TEXT_MAP, decoded.spanContextMap);
       } catch (e) {
-        // ignore decode failures. 
+        // ignore decode failures.
         return null;
       }
     }

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -1,9 +1,16 @@
+const path = require('path');
+const protobuf = require('protobufjs');
+
 const middleware = require('./tracer_middleware');
 const tracing = require('opentracing');
 const tracerFactory = require('./tracer_factory');
 const constants = require('./constants');
 
 const noop = function() {};
+
+const protoRoot = new protobuf.Root();
+protoRoot.loadSync(path.join(__dirname, 'trace_context.proto'))
+const SpanContext = protoRoot.lookupType('auth0.instrumentation.SpanContext');
 
 const Tags = Object.assign({
   AUTH0_TENANT: constants.TAG_AUTH0_TENANT,
@@ -20,7 +27,8 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
     _tracer: tracer,
     _logger: agent.logger,
     FORMAT_HTTP_HEADERS: tracing.FORMAT_HTTP_HEADERS,
-    FORMAT_TEXT_MAP: tracing.FORMAT_TEXT_MAP
+    FORMAT_TEXT_MAP: tracing.FORMAT_TEXT_MAP,
+    FORMAT_AUTH0_BINARY: 'format-auth0-binary'
   };
 
   obj.Tags = Tags;
@@ -54,10 +62,33 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
   };
 
   obj.inject = function(spanOrContext, format, carrier) {
+    if (format === obj.FORMAT_AUTH0_BINARY) {
+      const textCarrier = {};
+      obj.inject(spanOrContext, obj.FORMAT_TEXT_MAP, textCarrier);
+      const carrierMsg = SpanContext.create({
+        spanContextMap: textCarrier
+      });
+      console.log('carrier message', carrierMsg);
+      const encoded = SpanContext.encode(carrierMsg).finish();
+      return carrier(encoded);
+    }
     obj._tracer.inject(spanOrContext, format, carrier);
   };
 
   obj.extract = function(format, carrier) {
+    if (format === obj.FORMAT_AUTH0_BINARY) {
+      // Carrier should be a buffer containing a serialized
+      // SpanContext proto, which will we decode, then
+      // transform into a TEXT_MAP.
+      try {
+        const decoded = SpanContext.decode(carrier);
+        return obj.extract(obj.FORMAT_TEXT_MAP, decoded.spanContextMap);
+      } catch (e) {
+        console.log('failed to decode proto message', e);
+        //obj._logger.debug('failed to decode proto message', err);
+        return null;
+      }
+    }
     const span = obj._tracer.extract(format, carrier);
     return span ? wrapSpan(span) : span;
   };

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -65,7 +65,9 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
   // the specified format and carrier.
   // (see: https://github.com/opentracing/specification/blob/master/specification.md )
   // When using the AUTHO_BINARY format, `carrier` should be a function
-  // that will receive the opaque context payload.
+  // that will receive the opaque context payload. This function will
+  // not be called if injection fails, so it should not have other side
+  // effects.
   // e.g.
   // var context;
   // tracer.inject(span, tracer.FORMAT_AUTH0_BINARY, (ctx) => { context = ctx });
@@ -80,6 +82,7 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
       try {
         return carrier(encoded);
       } catch (err) {
+        return;
         // ignore failures to propagate
       }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "on-finished": "^2.3.0",
     "opentracing": "^0.14.3",
     "pidusage": "^1.0.4",
+    "protobufjs": "^6.8.8",
     "raven": "^0.10.0",
     "uuid": "^3.0.1",
     "v8-profiler-node8": "^5.7.6"

--- a/test/tracer_test.proto
+++ b/test/tracer_test.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package auth0.instrumentation;
+
+message TraceContextTest {
+  string name = 1;
+  bytes span_context = 2;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,49 @@
 # yarn lockfile v1
 
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
@@ -11,6 +54,14 @@
 "@sinonjs/samsam@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+
+"@types/node@^10.1.0":
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
 abbrev@1:
   version "1.1.1"
@@ -1340,6 +1391,10 @@ long@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+
 lru-cache@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
@@ -1766,6 +1821,24 @@ podium@^1.3.0:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+protobufjs@^6.8.8:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
 
 proxy-addr@~2.0.3:
   version "2.0.4"


### PR DESCRIPTION
This will be used to propagate trace context information in a standard way for services that don't use HTTP.

Example use:

// in service.proto
message MyRequest {
  // foo is a field used by the service.
  string foo = 1;

  // trace_context is an opaque field holding trace context
  bytes trace_context = 2;
};


// in code that needs to propagate
const req = MyRequest.create({foo: 'bar'})
tracer.inject(span, tracer.FORMAT_AUTH0_BINARY, (ctx) => { req.trace_context = ctx; })
// send req here


// in code that needs to extract
const wireCtx = tracer.extract(tracer.FORMAT_AUTH0_BINARY, req.trace_context)
const span = tracer.startSpan('op', { childOf: wireCtx });

