### PR TITLE
Increment version to 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This contains support for non-HTTP tracing formats, and
the lightstep tracing backend.