### PR TITLE
Tracing: Add a helper for wrapping outgoing requests made by 'request'

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,48 @@ var server = new hapi.Server();
 server.register(tracer.middleware.hapi16);
 ```
 
+There is also a helper for wrapping outgoing requests made by
+the `requests` HTTP client library.
+
+Wrapped requests will automatically be wrapped in a span, and
+contextual information will be injected into the headers
+of outgoing requests.
+
+```js
+var pkg = require('./package.json');
+var env = require('./lib/env');
+var agent = require('auth0-instrumentation');
+var request = require('request');
+
+agent.init(pkg, env);
+var tracer = agent.tracer;
+var wrapRequest = tracer.agent.helpers.wrapRequest;
+
+// This works with 'streams'
+wrapRequest(request)('http://example.com')
+  .on('response', (res) => {
+    console.log(res.statusCode);
+  });
+
+// And callbacks.
+wrapRequest(request)('http://example.com', (err, res, body) => {
+  console.log(res.statusCode);
+});
+
+// Additional span tags and any parent context may be passed
+// as options when creating the wrapper.
+const opts = {
+  spanTags: {
+    foo: 'bar'
+  },
+  parentSpan: someSpan
+};
+wrapRequest(opts, request)('http://example.com')
+  .on('response', (res) => {
+    console.log(res.statusCode);
+  });
+```
+
 ## Errors
 
 You can use the error reporter to send exceptions to an external service. You can set it up on your app in three ways, depending on what framework is being used.

--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -10,7 +10,9 @@ function tagsForResponse(tracer, span, response) {
   span.setTag(tracer.Tags.HTTP_METHOD, response.req.method);
 }
 
-module.exports = function wrapper(tracer) {
+// Given a tracer, return a function that is capable of
+// wrapping outgoing calls to 'request.js' in tracing spans.
+module.exports = function requestWrapper(tracer) {
   /** Wrap an outgoing call to request.js in a child span,
   * @param {Object} spanOpts - (optional) Options for the created span
   * @param {Object} spanOpts.spanTags - Additional tags to apply to the created span.

--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -1,0 +1,75 @@
+const extend = require('extend');
+const urlParse = require('url').parse;
+
+function tagsForResponse(tracer, span, response) {
+  const statusCode = response.statusCode;
+  span.setTag(tracer.Tags.HTTP_STATUS_CODE, statusCode);
+  if (response.error || statusCode >= 500) {
+    span.setTag(tracer.Tags.ERROR, true);
+  }
+  span.setTag(tracer.Tags.HTTP_METHOD, response.req.method);
+}
+
+module.exports = function wrapper(tracer) {
+  /** Wrap an outgoing call to request.js in a child span,
+  * @param {Object} spanOpts - (optional) Options for the created span
+  * @param {Object} spanOpts.spanTags - Additional tags to apply to the created span.
+  * @param {Object} spanOpts.parentSpan - A parent span, if any.
+  * @param {function} target - The target function (e.g. 'request', or 'request.get').
+  */
+  return function(spanOpts, target) {
+    const spanOptions = {};
+    if (typeof spanOpts === 'function') {
+      target = spanOpts;
+    } else {
+      extend(spanOptions, spanOpts);
+    }
+    return function(uri, options, callback) {
+      if (typeof options === 'function') {
+        callback = options;
+      }
+      const params = {};
+      if (typeof options === 'object') {
+        extend(params, options, { uri: uri });
+      } else if (typeof uri === 'string') {
+        extend(params, {uri: uri})
+      } else {
+        extend(params, uri);
+      }
+      const parsed = urlParse(params.uri);
+      const span = tracer.startSpan(parsed.pathname, { childOf: spanOptions.parentSpan });
+      span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_CLIENT);
+      span.setTag(tracer.Tags.HTTP_URL, params.uri);
+      if (spanOptions.spanTags) {
+        span.addTags(spanOptions.spanTags);
+      }
+      params.callback = callback || params.callback;
+      params.headers = params.headers || {};
+      tracer.inject(span, tracer.FORMAT_HTTP_HEADERS, params.headers);
+
+      if (!params.callback) {
+        return target(params)
+          .on('response', (response) => {
+            tagsForResponse(tracer, span, response);
+            span.finish();
+          })
+          .on('error', (err) => {
+            span.setTag(tracer.Tags.ERROR, true);
+            span.finish();
+          });
+      }
+      const originalCallback = params.callback;
+      params.callback = function(error, response, body) {
+        if (error) {
+          span.setTag(tracer.Tags.ERROR, true);
+        }
+        if (response) {
+          tagsForResponse(tracer, span, response);
+        }
+        span.finish();
+        originalCallback(error, response, body);
+      }
+      return target(params);
+    };
+  };
+}

--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -32,7 +32,7 @@ module.exports = function wrapper(tracer) {
       if (typeof options === 'object') {
         extend(params, options, { uri: uri });
       } else if (typeof uri === 'string') {
-        extend(params, {uri: uri})
+        extend(params, {uri: uri});
       } else {
         extend(params, uri);
       }
@@ -53,7 +53,7 @@ module.exports = function wrapper(tracer) {
             tagsForResponse(tracer, span, response);
             span.finish();
           })
-          .on('error', (err) => {
+          .on('error', (_err) => {
             span.setTag(tracer.Tags.ERROR, true);
             span.finish();
           });
@@ -68,8 +68,8 @@ module.exports = function wrapper(tracer) {
         }
         span.finish();
         originalCallback(error, response, body);
-      }
+      };
       return target(params);
     };
   };
-}
+};

--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -1,4 +1,3 @@
-const extend = require('extend');
 const urlParse = require('url').parse;
 
 function tagsForResponse(tracer, span, response) {
@@ -28,7 +27,7 @@ module.exports = function requestWrapper(tracer) {
     if (typeof spanOpts === 'function') {
       target = spanOpts;
     } else {
-      extend(spanOptions, spanOpts);
+      Object.assign(spanOptions, spanOpts);
     }
     return function(uri, options, callback) {
       if (typeof options === 'function') {
@@ -36,11 +35,11 @@ module.exports = function requestWrapper(tracer) {
       }
       const params = {};
       if (typeof options === 'object') {
-        extend(params, options, { uri: uri });
+        Object.assign(params, options, { uri: uri });
       } else if (typeof uri === 'string') {
-        extend(params, {uri: uri});
+        Object.assign(params, {uri: uri});
       } else {
-        extend(params, uri);
+        Object.assign(params, uri);
       }
       const parsed = urlParse(params.uri);
       const span = tracer.startSpan(parsed.pathname, { childOf: spanOptions.parentSpan });
@@ -56,11 +55,11 @@ module.exports = function requestWrapper(tracer) {
       if (!params.callback) {
         // stream response.
         return target(params)
-          .on('response', (response) => {
+          .once('response', (response) => {
             tagsForResponse(tracer, span, response);
             span.finish();
           })
-          .on('error', (_err) => {
+          .once('error', () => {
             span.setTag(tracer.Tags.ERROR, true);
             span.finish();
           });

--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -7,6 +7,10 @@ function tagsForResponse(tracer, span, response) {
   if (response.error || statusCode >= 500) {
     span.setTag(tracer.Tags.ERROR, true);
   }
+  // 'method' is set here, because certain call patterns
+  // of request (e.g. calling through an alias such as
+  // 'request.get' make it difficult to know before
+  // the request is made.
   span.setTag(tracer.Tags.HTTP_METHOD, response.req.method);
 }
 
@@ -50,6 +54,7 @@ module.exports = function requestWrapper(tracer) {
       tracer.inject(span, tracer.FORMAT_HTTP_HEADERS, params.headers);
 
       if (!params.callback) {
+        // stream response.
         return target(params)
           .on('response', (response) => {
             tagsForResponse(tracer, span, response);
@@ -60,6 +65,7 @@ module.exports = function requestWrapper(tracer) {
             span.finish();
           });
       }
+      // callback response.
       const originalCallback = params.callback;
       params.callback = function(error, response, body) {
         if (error) {

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const protobuf = require('protobufjs');
 
+const requestHelper = require('./trace_request');
 const middleware = require('./tracer_middleware');
 const tracing = require('opentracing');
 const tracerFactory = require('./tracer_factory');
@@ -132,6 +133,9 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
     hapi16: middleware.hapi16(obj)
   };
 
+  obj.helpers = {
+    wrapRequest: requestHelper(obj) 
+  };
 
   return obj;
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "blocked": "^1.2.1",
     "bunyan": "^1.8.1",
     "datadog-metrics": "^0.3.0",
+    "extend": "^3.0.2",
     "gc-stats": "1.0.2",
     "jaeger-client": "3.12.0",
     "lightstep-tracer": "^0.20.9",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocha": "^3.0.0",
     "nsp": "^2.5.0",
     "proxyquire": "^2.0.1",
+    "request": "^2.88.0",
     "sinon": "^6.1.4",
     "supertest": "^3.1.0",
     "yargs": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "blocked": "^1.2.1",
     "bunyan": "^1.8.1",
     "datadog-metrics": "^0.3.0",
-    "extend": "^3.0.2",
     "gc-stats": "1.0.2",
     "jaeger-client": "3.12.0",
     "lightstep-tracer": "^0.20.9",

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const protobuf = require('protobufjs');
 const request = require('supertest');
 const sinon = require('sinon');
+const requestjs = require('request');
 
 describe('tracer stub', function() {
   var $mock;
@@ -525,6 +526,194 @@ describe('auth0 binary format', function() {
     assert.doesNotThrow(() => { 
       const extracted = $tracer.extract($tracer.FORMAT_AUTH0_BINARY, 'bad data here');
       assert(!extracted);
+    });
+  });
+});
+
+describe('trace request helper', function() {
+  var $server;
+  var $mock;
+  var $tracer;
+  var $address;
+  var $wrapRequest;
+  before(function(done) {
+    const app = express();
+    app.get('/success', function(_req, res) {
+      res.status(200).send('ok');
+    });
+    app.get('/error', function(_req, res) {
+      res.status(500).send('error');
+    });
+    $server = require('http').createServer(app);
+    $server.listen((err) => {
+      if (err) {
+        return done(err);
+      }
+      $address = 'http://localhost:' + $server.address().port;
+      done();
+    });
+  });
+  beforeEach(function() {
+    $mock = new opentracing.MockTracer();
+    $mock.inject = function(span, format, carrier) {
+      carrier['x-span-id'] = span.uuid();
+    };
+    $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+    $wrapRequest = $tracer.helpers.wrapRequest;
+  });
+
+  describe('stream calls', function() {
+    it('should wrap simple requests in a span', function(done) {
+        const reqUrl = $address + '/success';
+        $wrapRequest(requestjs)(reqUrl)
+            .on('response', (res) => {
+                assert.equal(200, res.statusCode);
+                const report = $mock.report();
+                const span = report.firstSpanWithTagValue(
+                    $tracer.Tags.HTTP_STATUS_CODE, 200);
+                assert.ok(span);
+                assert.equal('/success', span.operationName());
+                assert.equal('GET', span.tags()[$tracer.Tags.HTTP_METHOD]);
+                done();
+            })
+            .on('error', err => done(err));
+    });
+
+    it('should add error tags', function(done) {
+      const reqUrl = $address + '/error';
+      $wrapRequest(requestjs)(reqUrl)
+        .on('response', (res) => {
+          assert.equal(500, res.statusCode);
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue(
+            $tracer.Tags.HTTP_STATUS_CODE, 500);
+          assert.ok(span);
+          assert.ok(span.tags()[$tracer.Tags.ERROR]);
+          done();
+        })
+        .on('error', (err) => {
+          done(err);
+        });
+
+    });
+
+    it('should add optional tags', function(done) {
+    const reqUrl = $address + '/success';
+    $wrapRequest({
+            spanTags: {
+                testTag: 'testVal'
+            }
+        }, requestjs)(reqUrl)
+        .on('response', (res) => {
+            assert.equal(200, res.statusCode);
+            const report = $mock.report();
+            const span = report.firstSpanWithTagValue('testTag', 'testVal');
+            assert.ok(span);
+            done();
+        })
+        .on('error', err => done(err));
+    });
+
+    it('should inject the span into the request', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs)(reqUrl)
+        .on('response', (res) => {
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
+          assert.ok(span);
+          assert.equal(span.uuid(), res.req.getHeader('x-span-id'));
+          done();
+        })
+        .on('error', err => done(err));
+    });
+
+    it('should work with method aliases', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs.get)(reqUrl)
+        .on('response', (res) => {
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
+          assert.ok(span);
+          assert.equal('GET', span.tags()[$tracer.Tags.HTTP_METHOD]);
+          done();
+        })
+        .on('error', err => done(err));
+    });
+
+    it('should work with params object', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs)({uri: reqUrl, method: 'get'})
+        .on('response', (res) => {
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
+          assert.ok(span);
+          assert.equal('GET', span.tags()[$tracer.Tags.HTTP_METHOD]);
+          done();
+        })
+        .on('error', err => done(err));
+    });
+  });
+
+  describe('calls with callback', function() {
+    it('should wrap spans', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs)(reqUrl, (err, res, _body) => {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(200, res.statusCode);
+        const report = $mock.report();
+        const span = report.firstSpanWithTagValue(
+          $tracer.Tags.HTTP_STATUS_CODE, 200);
+        assert.ok(span);
+        assert.equal('/success', span.operationName());
+        done();
+      });
+    });
+
+    it('should add error tags', function(done) {
+      const reqUrl = $address + '/error';
+      $wrapRequest(requestjs)(reqUrl, (err, res, _body) => {
+        assert.equal(500, res.statusCode);
+        const report = $mock.report();
+        const span = report.firstSpanWithTagValue(
+          $tracer.Tags.HTTP_STATUS_CODE, 500);
+        assert.ok(span);
+        assert.ok(span.tags()[$tracer.Tags.ERROR]);
+        done();
+      });
+    });
+
+    it('should add specified additional tags', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest({
+          spanTags: {
+              testTag: 'testVal'
+          }
+      }, requestjs)(reqUrl, (err, res, _body) => {
+          if (err) {
+              return done(err);
+          }
+          assert.equal(200, res.statusCode);
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue('testTag', 'testVal');
+          assert.ok(span);
+          done();
+      });
+    });
+
+    it('should inject the span into the request', function(done) {
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs)(reqUrl, (err, res, _body) => {
+        if (err) {
+          return done(err);
+        }
+        const report = $mock.report();
+        const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
+        assert.ok(span);
+        assert.equal(span.uuid(), res.req.getHeader('x-span-id'));
+        done();
+      });
     });
   });
 });

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -564,19 +564,19 @@ describe('trace request helper', function() {
 
   describe('stream calls', function() {
     it('should wrap simple requests in a span', function(done) {
-        const reqUrl = $address + '/success';
-        $wrapRequest(requestjs)(reqUrl)
-            .on('response', (res) => {
-                assert.equal(200, res.statusCode);
-                const report = $mock.report();
-                const span = report.firstSpanWithTagValue(
-                    $tracer.Tags.HTTP_STATUS_CODE, 200);
-                assert.ok(span);
-                assert.equal('/success', span.operationName());
-                assert.equal('GET', span.tags()[$tracer.Tags.HTTP_METHOD]);
-                done();
-            })
-            .on('error', err => done(err));
+      const reqUrl = $address + '/success';
+      $wrapRequest(requestjs)(reqUrl)
+        .on('response', (res) => {
+          assert.equal(200, res.statusCode);
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue(
+            $tracer.Tags.HTTP_STATUS_CODE, 200);
+          assert.ok(span);
+          assert.equal('/success', span.operationName());
+          assert.equal('GET', span.tags()[$tracer.Tags.HTTP_METHOD]);
+          done();
+        })
+        .on('error', err => done(err));
     });
 
     it('should add error tags', function(done) {
@@ -598,18 +598,18 @@ describe('trace request helper', function() {
     });
 
     it('should add optional tags', function(done) {
-    const reqUrl = $address + '/success';
-    $wrapRequest({
-            spanTags: {
-                testTag: 'testVal'
-            }
-        }, requestjs)(reqUrl)
+      const reqUrl = $address + '/success';
+      $wrapRequest({
+        spanTags: {
+          testTag: 'testVal'
+        }
+      }, requestjs)(reqUrl)
         .on('response', (res) => {
-            assert.equal(200, res.statusCode);
-            const report = $mock.report();
-            const span = report.firstSpanWithTagValue('testTag', 'testVal');
-            assert.ok(span);
-            done();
+          assert.equal(200, res.statusCode);
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue('testTag', 'testVal');
+          assert.ok(span);
+          done();
         })
         .on('error', err => done(err));
     });
@@ -631,6 +631,7 @@ describe('trace request helper', function() {
       const reqUrl = $address + '/success';
       $wrapRequest(requestjs.get)(reqUrl)
         .on('response', (res) => {
+          assert.equal(200, res.statusCode);
           const report = $mock.report();
           const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
           assert.ok(span);
@@ -644,6 +645,7 @@ describe('trace request helper', function() {
       const reqUrl = $address + '/success';
       $wrapRequest(requestjs)({uri: reqUrl, method: 'get'})
         .on('response', (res) => {
+          assert.equal(200, res.statusCode);
           const report = $mock.report();
           const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
           assert.ok(span);
@@ -687,18 +689,18 @@ describe('trace request helper', function() {
     it('should add specified additional tags', function(done) {
       const reqUrl = $address + '/success';
       $wrapRequest({
-          spanTags: {
-              testTag: 'testVal'
-          }
+        spanTags: {
+          testTag: 'testVal'
+        }
       }, requestjs)(reqUrl, (err, res, _body) => {
-          if (err) {
-              return done(err);
-          }
-          assert.equal(200, res.statusCode);
-          const report = $mock.report();
-          const span = report.firstSpanWithTagValue('testTag', 'testVal');
-          assert.ok(span);
-          done();
+        if (err) {
+          return done(err);
+        }
+        assert.equal(200, res.statusCode);
+        const report = $mock.report();
+        const span = report.firstSpanWithTagValue('testTag', 'testVal');
+        assert.ok(span);
+        done();
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,7 +1107,7 @@ extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extend@~3.0.2:
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,15 +2202,15 @@ long@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
 
 lru-cache@^4.0.1:
   version "4.1.2"
@@ -3143,7 +3143,7 @@ request@^2.27.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.85.0:
+request@^2.85.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,7 +1107,7 @@ extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extend@^3.0.2, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 


### PR DESCRIPTION
This helper makes it easier to wrap outgoing requests made by the 'request' HTTP client library
in client spans, and automatically propagate the resulting context for correlation by downstream
services.