### PR TITLE
Fix profile GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,71 @@
 # Changelog
+<a name="v2.19.0"></a>
+# v2.19.0
+### Bugfix
+* Fix undefined function call when using `PROFILE_GC` and not `HUNT_MEMORY_LEAKS`
+### Feature
+* Add HTTP request wrapper
+* https://github.com/auth0/auth0-instrumentation/compare/v2.18.0...v2.19.0
+
+<a name="v2.18.0"></a>
+# v2.18.0
+### Feature
+* Add Lighstep tracker backend
+* https://github.com/auth0/auth0-instrumentation/compare/v2.17.0...v2.18.0
+
+<a name="v2.17.0"></a>
+# v2.17.0
+### Feature
+* Add tracing support
+* https://github.com/auth0/auth0-instrumentation/compare/v2.16.0...v2.17.0
+
+<a name="v2.16.0"></a>
+# v2.16.0
+### Feature
+* `endTime` returns the elapsed time
+* https://github.com/auth0/auth0-instrumentation/compare/v2.15.1...v2.16.0
+
+<a name="v2.15.1"></a>
+# v2.15.1
+### Bugfix
+* Add `observeBucketed` to metic stubs
+* https://github.com/auth0/auth0-instrumentation/compare/v2.15.0...v2.15.1
+
+<a name="v2.15.0"></a>
+# v2.15.0
+### Bugfix
+* Upgrade aws-kinesis-writable library to 4.2.0
+### Feature
+* Add `observeBucketed` metric type.
+* https://github.com/auth0/auth0-instrumentation/compare/v2.14.1...v2.15.0
+
+<a name="v2.14.1"></a>
+# v2.14.1
+### Bugfix
+* Do not default to `undefined` for `purpose` and `environment`
+* https://github.com/auth0/auth0-instrumentation/compare/v2.14.0...v2.14.1
+
+<a name="v2.14.0"></a>
+# v2.14.0
+### Feature
+* Include `purpose` and `environment` on log messages from `ENVIRONMENT` and `PURPOSE` env variables
+* https://github.com/auth0/auth0-instrumentation/compare/v2.13.1...v2.14.0
+
+<a name="v2.13.1"></a>
+# v2.13.1
+### Feature
+* Add `incrementOne` to metrics
+* https://github.com/auth0/auth0-instrumentation/compare/v2.13.0...v2.13.1
+
+<a name="v2.13.0"></a>
+# v2.13.0
+### Feature
+* Allow logging to file using `LOG_FILE` option
+* https://github.com/auth0/auth0-instrumentation/compare/v2.12.1...v2.13.0
+
 <a name="v2.12.1"></a>
 # v2.12.1
-### Buf Fix
+### Bug Fix
 * Avoid pushing debug/info logs to Sentry as exceptions
 * https://github.com/auth0/auth0-instrumentation/compare/v2.12.0...v2.12.1
 

--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -135,7 +135,7 @@ Profiler.prototype.setupGCReporter = function setupGCReporter() {
         }, ms('5s'));
       }
 
-      this.agent.logger.error('long GC pause', {
+      this.agent.logger.info('long GC pause', {
         time: startedAt.toISOString(),
         gc_info: {
           startedAt: startedAt,

--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -10,13 +10,14 @@ const throttle = require('lodash.throttle');
 process.send = process.send || function () {};
 
 function Profiler(agent, pkg, env) {
-  this.huntMemoryLeaks = env.HUNT_MEMORY_LEAKS;
+  this.heapDumpOnGc = env.HUNT_LONG_GC;
+  this.heapDumpOnHighMemory = env.HUNT_MEMORY_LEAKS;
   this.agent = agent;
   this.heapshotDir = env.HEAPDUMP_DIR || '/tmp';
   this.serviceName = pkg.name;
+  this.createThrottledSnapshot = throttle((reason) => this.createSnapshot(reason), ms('5m'));
 
   if (env.HUNT_MEMORY_LEAKS) {
-    this.createThrottledSnapshot = throttle((reason) => this.createSnapshot(reason), ms('5m'));
     this.setupProcessListener();
   }
 
@@ -35,7 +36,7 @@ Profiler.prototype.setupProcessListener = function setupProcessListener() {
       return;
     }
 
-    if (!message || message.msg !== 'mem_high' || !this.huntMemoryLeaks) {
+    if (!message || message.msg !== 'mem_high' || !this.heapDumpOnHighMemory) {
       return;
     }
 
@@ -128,11 +129,13 @@ Profiler.prototype.setupGCReporter = function setupGCReporter() {
     if (info && info.pauseMS > 500) {
       const startedAt = new Date(Date.now() - info.pauseMS);
 
-      setTimeout(() => {
-        this.createThrottledSnapshot('LONG_GC_PAUSE');
-      }, ms('5s'));
+      if (this.heapDumpOnGc) {
+        setTimeout(() => {
+          this.createThrottledSnapshot('LONG_GC_PAUSE');
+        }, ms('5s'));
+      }
 
-      this.agent.logger.info('long GC pause', {
+      this.agent.logger.error('long GC pause', {
         time: startedAt.toISOString(),
         gc_info: {
           startedAt: startedAt,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-
+var $require = require('proxyquire').noPreserveCache();
 const Profiler = require('../lib/profiler');
 
 describe('Profiler', function() {
@@ -11,7 +11,8 @@ describe('Profiler', function() {
         histogram: sinon.spy()
       },
       logger: {
-        info: sinon.spy()
+        info: sinon.spy(),
+        error: sinon.spy()
       }
     };
     profiler = new Profiler(agent, { name: 'test' }, { HUNT_MEMORY_LEAKS: true });
@@ -52,6 +53,61 @@ describe('Profiler', function() {
         } catch (err) {
           done(err);
         }
+      });
+    });
+  });
+
+  describe('#setupGCReporter', () => {
+    const EventEmitter = require('events');
+    const stats = new EventEmitter();
+    function getProfiler(env) {
+      const Profiler = $require('../lib/profiler', {
+        'gc-stats': () => stats
+      });
+
+      return new Profiler(agent, { name: 'test' }, env);
+    }
+
+    describe('when there is a new GC stat', () => {
+      let clock;
+      beforeEach(() => {
+        clock = sinon.useFakeTimers(new Date(), 'setTimeout');
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it ('does not takes snapshot', () => {
+        const profiler = getProfiler({ PROFILE_GC: true });
+        profiler.setupGCReporter();
+
+        const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
+        stats.emit('stats', { pauseMS: 1000 });
+        clock.tick(6000);
+        sinon.assert.notCalled(createSnapshotStub);
+      });
+
+      describe('and HUNT_LONG_GC is set', () => {
+        it('does not take snapshot if pause <= 500', () => {
+          const profiler = getProfiler({ PROFILE_GC: true, HUNT_LONG_GC: true });
+          profiler.setupGCReporter();
+          stats.emit('stats', { pauseMS: 500 });
+          clock.tick(6000);
+          const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
+          sinon.assert.notCalled(createSnapshotStub);
+        });
+
+        it('takes snapshot if pause > 500', () => {
+          const profiler = getProfiler({ PROFILE_GC: true, HUNT_LONG_GC: true });
+          const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
+
+          profiler.setupGCReporter();
+          stats.emit('stats', { pauseMS: 501 });
+          clock.tick(6000);
+          sinon.assert.calledOnce(createSnapshotStub);
+          sinon.assert.calledWith(createSnapshotStub, 'LONG_GC_PAUSE');
+        });
       });
     });
   });

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -11,8 +11,7 @@ describe('Profiler', function() {
         histogram: sinon.spy()
       },
       logger: {
-        info: sinon.spy(),
-        error: sinon.spy()
+        info: sinon.spy()
       }
     };
     profiler = new Profiler(agent, { name: 'test' }, { HUNT_MEMORY_LEAKS: true });
@@ -29,7 +28,7 @@ describe('Profiler', function() {
       // this test can be flaky, due to slowness in writing or snapshotting.
       this.retries(3);
       sinon.replace(profiler, 'report', sinon.spy());
-      this.timeout(3000);
+      this.timeout(5000);
       profiler.createThrottledSnapshot('testing');
       setTimeout(() => {
         try {
@@ -44,7 +43,7 @@ describe('Profiler', function() {
 
   describe('#createProfile', function() {
     it('should create a profile', function(done) {
-      this.timeout(3000);
+      this.timeout(5000);
       profiler.createProfile(1000, function(err, path) {
         try {
           assert.ifError(err);
@@ -59,8 +58,9 @@ describe('Profiler', function() {
 
   describe('#setupGCReporter', () => {
     const EventEmitter = require('events');
-    const stats = new EventEmitter();
+    let stats;
     function getProfiler(env) {
+      stats = new EventEmitter();
       const Profiler = $require('../lib/profiler', {
         'gc-stats': () => stats
       });
@@ -89,9 +89,9 @@ describe('Profiler', function() {
       describe('and HUNT_LONG_GC is set', () => {
         it('does not take snapshot if pause <= 500', () => {
           const profiler = getProfiler({ PROFILE_GC: true, HUNT_LONG_GC: true });
+          const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
           stats.emit('stats', { pauseMS: 500 });
           clock.tick(6000);
-          const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
           sinon.assert.notCalled(createSnapshotStub);
         });
 

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -80,8 +80,6 @@ describe('Profiler', function() {
 
       it ('does not takes snapshot', () => {
         const profiler = getProfiler({ PROFILE_GC: true });
-        profiler.setupGCReporter();
-
         const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
         stats.emit('stats', { pauseMS: 1000 });
         clock.tick(6000);
@@ -91,7 +89,6 @@ describe('Profiler', function() {
       describe('and HUNT_LONG_GC is set', () => {
         it('does not take snapshot if pause <= 500', () => {
           const profiler = getProfiler({ PROFILE_GC: true, HUNT_LONG_GC: true });
-          profiler.setupGCReporter();
           stats.emit('stats', { pauseMS: 500 });
           clock.tick(6000);
           const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
@@ -101,8 +98,6 @@ describe('Profiler', function() {
         it('takes snapshot if pause > 500', () => {
           const profiler = getProfiler({ PROFILE_GC: true, HUNT_LONG_GC: true });
           const createSnapshotStub = sinon.stub(profiler, 'createSnapshot');
-
-          profiler.setupGCReporter();
           stats.emit('stats', { pauseMS: 501 });
           clock.tick(6000);
           sinon.assert.calledOnce(createSnapshotStub);

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const sinon = require('sinon');
-var $require = require('proxyquire').noPreserveCache();
+const $require = require('proxyquire').noPreserveCache();
 const Profiler = require('../lib/profiler');
 
 describe('Profiler', function() {
-  var profiler, agent;
+  let profiler, agent;
   beforeEach(function() {
     agent = {
       metrics: {


### PR DESCRIPTION
When PROFILE_GC is set but HUNT_MEMORY_LEAKS is not, an uncaught is thrown because the `createThrottledSnapshot` function is not defined. 

This caused an uncaught on the auth0-mfa-api service: https://auth0.slack.com/archives/C04SSNEKT/p1538487947000100

This PR fix the issue by always creating the function, and adds a new env variable to opt in to get snapshots.

In the case of MFA we are interested in getting the GC stats, but not in getting heapdumps.

The change will also make that any service using `PROFILE_GC` will stop getting heapdumps until this new env variable is defined. As far as I know, no service is now using dumps created by GC blocks. In fact, we use `PROFILE_GC = true` without `HUNT_MEMORY_LEAKS` in most services (https://github.com/auth0/auth0-configuration/blob/ac7fae0a66450079cb59d8a19122630eaba6bdf3/hiera/common/us_amazon_west.json#L261).

Testing:
* Unit tests
