### PR TITLE
Support 'url' as a synonym for 'uri' when wrapping 'request'.

### DIFF
--- a/lib/trace_request.js
+++ b/lib/trace_request.js
@@ -41,10 +41,11 @@ module.exports = function requestWrapper(tracer) {
       } else {
         Object.assign(params, uri);
       }
-      const parsed = urlParse(params.uri);
+      // request permits 'url' as a synonym for 'uri'.
+      const parsed = urlParse(params.uri || params.url);
       const span = tracer.startSpan(parsed.pathname, { childOf: spanOptions.parentSpan });
       span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_CLIENT);
-      span.setTag(tracer.Tags.HTTP_URL, params.uri);
+      span.setTag(tracer.Tags.HTTP_URL, parsed.href);
       if (spanOptions.spanTags) {
         span.addTags(spanOptions.spanTags);
       }

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -747,5 +747,22 @@ describe('trace request helper', function() {
       };
       $wrapRequest(requestjs)(params);
     });
+
+    it('should support "url" as a synonym for "uri" in params', function(done) {
+      const params = {
+        url: $address + '/success',
+        callback: (err, res, _body) => {
+          if (err) {
+            return done(err);
+          }
+          assert.equal(200, res.statusCode);
+          const report = $mock.report();
+          const span = report.firstSpanWithTagValue($tracer.Tags.HTTP_STATUS_CODE, 200);
+          assert.ok(span);
+          done();
+        }
+      };
+      $wrapRequest(requestjs)(params);
+    });
   });
 });


### PR DESCRIPTION
This maintains compatibility with 'request', which permits the
commonly used 'url' as an alternate name for 'uri'.