### PR TITLE
Add empty Tags property to tracer stub

### DIFF
--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -9,14 +9,15 @@ var emptySpan = {
   setTag: noop,
   addTags: noop,
   context: returnNull,
-  tracer: () => { return emptyTracer },
+  tracer: () => { return emptyTracer; },
   setOperationName: noop,
 };
 
 var emptyTracer = {
   startSpan: () => { return emptySpan; },
   inject: noop,
-  extract: returnNull
+  extract: returnNull,
+  Tags: {}
 };
 
 const emptyLogger = {

--- a/test/stubs.test.js
+++ b/test/stubs.test.js
@@ -159,6 +159,10 @@ describe('stubs', function() {
       assert.doesNotThrow(tracer.extract, Error);
     });
 
+    it('should get Tags without throwing', function() {
+      assert.doesNotThrow(function() { return tracer.Tags.AUTH0_TENANT; }, Error);
+    });
+
     const span = tracer.startSpan('foo');
     describe('tracer', function() {
 


### PR DESCRIPTION
* Fix undefined Tags property error when tracer isn't activated.