### PR TITLE
Tracing: Add tracing plugin for hapi17

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ var app = express();
 app.use(tracer.middleware.express);
 ```
 
-For hapijs (only hapi16 is currently supported).
+For hapijs:
+
+Version 16 (and below)
+
 
 ```js
 var pkg = require('./package.json');
@@ -128,6 +131,21 @@ var server = new hapi.Server();
 // the hapi request lifecycle.
 server.register(tracer.middleware.hapi16);
 ```
+
+Version 17 (and above)
+```
+const pkg = require('/package.json');
+const env = require('./lib/env');
+const agent = require('auth0-instrumentation');
+var hapi = require('hapi');
+
+agent.init(pkg, env);
+const tracer = agent.tracer;
+
+const server = new hapi.Server();
+await server.register(tracer.middlware.hapi17);
+```
+
 
 There is also a helper for wrapping outgoing requests made by
 the `requests` HTTP client library.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ agent.init(pkg, env);
 const tracer = agent.tracer;
 
 const server = new hapi.Server();
-await server.register(tracer.middlware.hapi17);
+await server.register(tracer.middleware.hapi17);
 ```
 
 

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -130,7 +130,8 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
   // Add middleware hooks.
   obj.middleware = {
     express: middleware.express(obj),
-    hapi16: middleware.hapi16(obj)
+    hapi16: middleware.hapi16(obj),
+    hapi17: middleware.hapi17(obj)
   };
 
   obj.helpers = {

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -13,6 +13,75 @@ function createRequestSpan(tracer, req) {
   return span;
 }
 
+function hapiHelper(tracer) {
+  const h = {tracer: tracer};
+  h.decorateRequest = (req) => {
+    const span = createRequestSpan(h.tracer, req);
+    return {
+      span: span,
+      tracer: tracer
+    };
+  };
+
+  h.onPreAuth = (req) => {
+    req.a0trace.auth = tracer.startSpan('auth', { childOf: req.a0trace.span });
+  };
+
+  h.onPostAuth = (req) => {
+    req.a0trace.auth.setTag('auth.isAuthenticated', req.auth.isAuthenticated);
+    req.a0trace.auth.setTag('auth.mode', req.auth.mode);
+    req.a0trace.auth.finish();
+    req.a0trace.auth = null;
+  };
+
+  h.onPreHandler = (req) => {
+    req.a0trace.handler = h.tracer.startSpan('handler', { childOf: req.a0trace.span });
+  };
+
+  h.onPreResponse = (req) => {
+    // We may not have an active handler span, since it's possible
+    // to skip directly to the response step if routing fails.
+    // See: https://hapijs.com/api/16.6.2#request-lifecycle
+    if (req.a0trace.handler) {
+      req.a0trace.handler.finish();
+      req.a0trace.handler = null;
+    }
+    const response = req.response;
+    const statusCode = response.isBoom ? response.output.statusCode : response.statusCode;
+
+    // set final request status on the primary span.
+    req.a0trace.span.setTag(h.tracer.Tags.HTTP_STATUS_CODE, statusCode);
+    if (statusCode >= 500) {
+      req.a0trace.span.setTag(h.tracer.Tags.ERROR, true);
+      req.a0trace.span.setTag(h.tracer.Tags.SAMPLING_PRIORITY, 1);
+    }
+
+    // Inject headers for the request span into the response, for debugging.
+    const responseHeaders = {};
+    tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+    if (response.isBoom) {
+      Object.keys(responseHeaders).forEach((key) => { response.output.headers[key] = responseHeaders[key]; });
+    } else {
+      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+    }
+
+    // will be automatically finished by the response event.
+    req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
+  };
+
+  h.finishSpans = (req) => {
+    if (req && req.a0trace) {
+      for (const key of Object.keys(req.a0trace)) {
+        const span = req.a0trace[key];
+        if (span && span.finish) {
+          span.finish();
+        }
+      }
+    }
+  };
+  return h;
+};
+
 module.exports = {
   express: function(tracer) {
     const mw = (req, res, next) => {
@@ -100,84 +169,32 @@ module.exports = {
 
   hapi16: function(tracer) {
 
-    const startSpans = (req) => {
-      const span = createRequestSpan(tracer, req);
-      return {
-        span: span,
-        tracer: tracer
-      };
-    };
-
-    const onPreAuth = (req, reply) => {
-      req.a0trace.auth = tracer.startSpan('auth', { childOf: req.a0trace.span });
-      reply.continue();
-    };
-
-    const onPostAuth = (req, reply) => {
-      req.a0trace.auth.setTag('auth.isAuthenticated', req.auth.isAuthenticated);
-      req.a0trace.auth.setTag('auth.mode', req.auth.mode);
-      req.a0trace.auth.finish();
-      req.a0trace.auth = null;
-      reply.continue();
-    };
-
-    const onPreHandler = (req, reply) => {
-      req.a0trace.handler = tracer.startSpan('handler', { childOf: req.a0trace.span });
-      reply.continue();
-    };
-
-    const onPreResponse = (req, reply) => {
-      // We may not have an active handler span, since it's possible
-      // to skip directly to the response step if routing fails.
-      // See: https://hapijs.com/api/16.6.2#request-lifecycle
-      if (req.a0trace.handler) {
-        req.a0trace.handler.finish();
-        req.a0trace.handler = null;
-      }
-      const response = req.response;
-      const statusCode = response.isBoom ? response.output.statusCode : response.statusCode;
-
-      // set final request status on the primary span.
-      req.a0trace.span.setTag(tracer.Tags.HTTP_STATUS_CODE, statusCode);
-      if (statusCode >= 500) {
-        req.a0trace.span.setTag(tracer.Tags.ERROR, true);
-        req.a0trace.span.setTag(tracer.Tags.SAMPLING_PRIORITY, 1);
-      }
-
-      // Inject headers for the request span into the response, for debugging.
-      const responseHeaders = {};
-      tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
-      if (response.isBoom) {
-        Object.keys(responseHeaders).forEach((key) => { response.output.headers[key] = responseHeaders[key]; });
-      } else {
-        Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
-      }
-
-      // will be automatically finished by the response event.
-      req.a0trace.response = tracer.startSpan('response', { childOf: req.a0trace.span });
-      reply.continue();
-    };
-
-    const finishSpans = (req) => {
-      if (req && req.a0trace) {
-        for (const key of Object.keys(req.a0trace)) {
-          const span = req.a0trace[key];
-          if (span && span.finish) {
-            span.finish();
-          }
-        }
-      }
-    };
+    const helper = hapiHelper(tracer);
 
     const register = function(server, options, next) {
-      server.decorate('request', 'a0trace',  startSpans, {apply: true});
+      server.decorate('request', 'a0trace',  helper.decorateRequest, {apply: true});
 
-      server.ext('onPreAuth', onPreAuth);
-      server.ext('onPostAuth', onPostAuth);
-      server.ext('onPreHandler', onPreHandler);
-      server.ext('onPreResponse', onPreResponse);
+      server.ext('onPreAuth', (req, reply) => {
+        helper.onPreAuth(req);
+        reply.continue();
+      });
 
-      server.on('response', finishSpans);
+      server.ext('onPostAuth', (req, reply) => {
+        helper.onPostAuth(req);
+        reply.continue();
+      });
+
+      server.ext('onPreHandler', (req, reply) => {
+        helper.onPreHandler(req);
+        reply.continue();
+      });
+
+      server.ext('onPreResponse', (req, reply) => {
+        helper.onPreResponse(req);
+        reply.continue();
+      });
+
+      server.on('response', helper.finishSpans);
       next();
     };
 
@@ -193,19 +210,33 @@ module.exports = {
       name: 'a0trace',
       version: '1.0.0',
     };
-    const finishSpans = (req) => {
-      if (req && req.a0trace) {
-        for (const key of Object.keys(req.a0trace)) {
-          const span = req.a0trace[key];
-          if (span && span.finish) {
-            span.finish();
-          }
-        }
-      }
-    };
+    const helper = hapiHelper(tracer);
+
     plugin.register = function(server, options) {
-      server.decorate('request', 'a0trace', startSpans, {apply: true, once: true});
-      server.on('response', finishSpans);
+      server.decorate('request', 'a0trace', helper.decorateRequest, {apply: true, once: true});
+
+      server.ext('onPreAuth', (req, reply) => {
+        helper.onPreAuth(req);
+        return reply.continue;
+      });
+
+      server.ext('onPostAuth', (req, reply) => {
+        helper.onPostAuth(req);
+        return reply.continue;
+      });
+
+      server.ext('onPreHandler', (req, reply) => {
+        helper.onPreHandler(req);
+        return reply.continue;
+      });
+
+      server.ext('onPreResponse', (req, reply) => {
+        helper.onPreResponse(req);
+        return reply.continue;
+      });
+
+      server.events.on('response', helper.finishSpans);
     };
+    return plugin;
   }
 };

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -60,9 +60,13 @@ function hapiHelper(tracer) {
     const responseHeaders = {};
     tracer.inject(req.a0trace.span, tracer.FORMAT_TEXT_MAP, responseHeaders);
     if (response.isBoom) {
-      Object.keys(responseHeaders).forEach((key) => { response.output.headers[key] = responseHeaders[key]; });
+      Object.keys(responseHeaders).forEach((key) => {
+          response.output.headers[key] = responseHeaders[key];
+      });
     } else {
-      Object.keys(responseHeaders).forEach((key) => { response.header(key, responseHeaders[key]); });
+      Object.keys(responseHeaders).forEach((key) => {
+          response.header(key, responseHeaders[key]);
+      });
     }
 
     // will be automatically finished by the response event.

--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -186,5 +186,26 @@ module.exports = {
     };
 
     return register;
+  },
+
+  hapi17: function(tracer) {
+    const plugin = {
+      name: 'a0trace',
+      version: '1.0.0',
+    };
+    const finishSpans = (req) => {
+      if (req && req.a0trace) {
+        for (const key of Object.keys(req.a0trace)) {
+          const span = req.a0trace[key];
+          if (span && span.finish) {
+            span.finish();
+          }
+        }
+      }
+    };
+    plugin.register = function(server, options) {
+      server.decorate('request', 'a0trace', startSpans, {apply: true, once: true});
+      server.on('response', finishSpans);
+    };
   }
 };

--- a/test/tracer.test.node8.js
+++ b/test/tracer.test.node8.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const hapi17 = require('hapi17');
+const opentracing = require('opentracing');
+const sinon = require('sinon');
+
+describe('tracer hapi17 middleware', function() {
+  // We expect 4 spans:
+  //  - request (top level span)
+  //  - auth
+  //  - handler
+  //  - response
+  const SPAN_COUNT = 4;
+  describe('middleware with stubs', async function() {
+    var server;
+    var mock;
+    var tracer;
+    beforeEach(async () => {
+      mock = new opentracing.MockTracer();
+      mock.inject = (span, format, carrier) => {
+        carrier['x-span-id'] = span.uuid();
+      };
+      mock.extract = sinon.fake();
+      tracer = require('../lib/tracer')({}, {}, {}, mock);
+
+      server = new hapi17.Server({port: 9999});
+      server.route({
+        method: 'GET',
+        path: '/success',
+        handler: async (request) => {
+          return 'ok'
+        }
+      });
+      server.route({
+        method: 'GET',
+        path: '/failure',
+        handler: async (_request, reply) => {
+          return reply.response('server error').code(500);
+        }
+      });
+      server.route({
+        method: 'GET',
+        path: '/error',
+        handler: async () => {
+          throw new Error('failure');
+        }
+      });
+      server.route({
+        method: 'GET',
+        path: '/moreinfo',
+        handler: async (request, reply) => {
+          request.a0trace.span.setTag('more_info', 'here');
+          return 'ok';
+        }
+      });
+      await server.register(tracer.middleware.hapi17);
+      await server.start();
+    });
+
+    afterEach(async () => {
+      await server.stop();
+    });
+
+    it('should create new child spans', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/success` };
+      const res = await server.inject(req);
+      assert.equal(200, res.statusCode);
+      const report = mock.report();
+      assert.equal(SPAN_COUNT, report.spans.length);
+      const reqSpan = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 200);
+      assert.ok(reqSpan);
+      assert.equal('/success', reqSpan.operationName());
+    });
+
+    it('should set error tags on failure', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/failure` };
+      const res = await server.inject(req);
+      assert.equal(500, res.statusCode);
+      const report = mock.report();
+      assert.equal(SPAN_COUNT, report.spans.length);
+      const reqSpan = report.firstSpanWithTagValue(tracer.Tags.ERROR, true);
+      assert.ok(reqSpan);
+      assert.equal('/failure', reqSpan.operationName());
+    });
+
+    it('should set error tags on exceptions', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/error` };
+      const res = await server.inject(req);
+      assert.equal(500, res.statusCode);
+      const report = mock.report();
+      assert.equal(SPAN_COUNT, report.spans.length);
+      const reqSpan = report.firstSpanWithTagValue(tracer.Tags.ERROR, true);
+      assert.ok(reqSpan);
+      assert.equal('/error', reqSpan.operationName());
+    });
+
+    it('should include span headers in the response when successful', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/success` };
+      const res = await server.inject(req);
+      assert.equal(200, res.statusCode);
+      const report = mock.report();
+      const child = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 200);
+      assert.ok(child);
+      assert.equal(child.uuid(), res.headers['x-span-id']);
+    });
+
+    it('should include span headers in the response for failures', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/error` };
+      const res = await server.inject(req);
+      assert.equal(500, res.statusCode);
+      const report = mock.report();
+      const child = report.firstSpanWithTagValue(tracer.Tags.HTTP_STATUS_CODE, 500);
+      assert.ok(child);
+      assert.equal(child.uuid(), res.headers['x-span-id']);
+    });
+
+    it('should make the created span available to handlers', async function() {
+      const req = { method: 'GET', url: `${server.info.uri}/moreinfo` };
+      const res = await server.inject(req);
+      assert.equal(200, res.statusCode);
+      const report = mock.report();
+      assert.equal(4, report.spans.length);
+      const reqSpan = report.firstSpanWithTagValue('more_info', 'here');
+      assert.ok(reqSpan);
+      assert.equal('/moreinfo', reqSpan.operationName());
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for automatic tracing of the hapi17 request lifecycle via plugin. Functionality should be identical to the existing hapi16 support.