### PR TITLE
Remove object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 <a name="v2.22.0"></a>
 # v2.22.0
 ### Bugfix
-* Fix error in metrics' flush method when Datadog and StatsD are both configured
 * Fix span wrapping error that caused tracer to leak memory when using lightstep tracer
 ### Feature
 * Add support to disable the trace on-the-fly (switchable tracer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
+
+<a name="v2.22.0"></a>
+# v2.22.0
+### Bugfix
+* Fix error in metrics' flush method when Datadog and StatsD are both configured
+* Fix span wrapping error that caused tracer to leak memory when using lightstep tracer
+### Feature
+* Add support to disable the trace on-the-fly (switchable tracer)
+* Improve exception handling and logging
+* https://github.com/auth0/auth0-instrumentation/compare/v2.20.0...v2.20.1
+
 <a name="v2.21.0"></a>
 # v2.21.0
 ### Feature
 * Add `region`/`environment`/`channel` tags to sentry events
 * https://github.com/auth0/auth0-instrumentation/compare/v2.20.1...v2.21.0
-
-<a name="v2.20.1"></a>
-# v2.20.1
-### Bugfix
-* Fix error in metrics' flush method when Datadog and StatsD are both configured 
-* https://github.com/auth0/auth0-instrumentation/compare/v2.20.0...v2.20.1
 
 <a name="v2.20.0"></a>
 # v2.20.0

--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ const env = {
   'METRICS_FLUSH_INTERVAL': 15, // seconds
 
   // Tracing configuration
-  'TRACE_AGENT_CLIENT': undefined, // e.g. 'jaeger'
+  'TRACE_AGENT_API_KEY': undefined,
+  'TRACE_AGENT_CLIENT': undefined, // e.g. 'jaeger', 'lightstep'
+  'TRACE_AGENT_USE_TLS': true,
   'TRACE_AGENT_HOST': 'localhost',
   'TRACE_AGENT_PORT': 6832
 };

--- a/README.md
+++ b/README.md
@@ -345,7 +345,8 @@ const env = {
   'TRACE_AGENT_CLIENT': undefined, // e.g. 'jaeger', 'lightstep'
   'TRACE_AGENT_USE_TLS': true,
   'TRACE_AGENT_HOST': 'localhost',
-  'TRACE_AGENT_PORT': 6832
+  'TRACE_AGENT_PORT': 443,
+  'TRACE_REPORTING_INTERVAL_MILLIS': 500
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ module.exports = {
     this.errorReporter = ErrorReporter(pkg, env);
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
-    this.tracer = Tracer(this, pkg, env, { isEnabled: params && params.isEnabled });
+    this.tracer = Tracer(this, pkg, env, {
+      isEnabled: params && params.isEnabled,
+      logger: this.logger
+    });
     this.initialized = true;
 
     if (params && params.fileRotationSignal && env.LOG_FILE) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     this.errorReporter = ErrorReporter(pkg, env);
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
-    this.tracer = Tracer(this, pkg, env);
+    this.tracer = Tracer(this, pkg, env, { isEnabled: params && params.isEnabled });
     this.initialized = true;
 
     if (params && params.fileRotationSignal && env.LOG_FILE) {

--- a/lib/switchable_tracer.js
+++ b/lib/switchable_tracer.js
@@ -1,0 +1,50 @@
+/**
+ * This is a temporary version of the tracer that accepts an
+ * option to enable / disable it. Since tracing might be expensive
+ * this feature is useful to enable / disable it if we note issues
+ * or we need to save resources for some reason
+ */
+
+module.exports = function switchableTracer(options) {
+  const baseTracer = options.baseTracer;
+  const tracerStubs = options.tracerStubs;
+  const isEnabled = options.isEnabled;
+
+  function isProtectedEnabled() {
+    try {
+      return isEnabled();
+    } catch (_) {
+      // Not much to do with the error but we don't want
+      // to fail; ideally we should log it but the logger might
+      // not be initialized at this point
+      return false;
+    }
+  }
+
+  return {
+    baseTracer,
+    tracerStubs,
+    startSpan: (name, options) => {
+      if (isProtectedEnabled()) {
+        return baseTracer.startSpan(name, options);
+      }
+
+      return tracerStubs.startSpan(name, options);
+    },
+    inject: (spanContext, format, carrier) => {
+      if (isProtectedEnabled()) {
+        return baseTracer.inject(spanContext, format, carrier);
+      }
+
+      return tracerStubs.inject(spanContext, format, carrier);
+    },
+    extract: (format, carrier) => {
+      if (isProtectedEnabled()) {
+        return baseTracer.extract(format, carrier);
+      }
+
+      return tracerStubs.extract(format, carrier);
+    },
+    Tags: baseTracer.Tags
+  };
+};

--- a/lib/switchable_tracer.js
+++ b/lib/switchable_tracer.js
@@ -9,14 +9,19 @@ module.exports = function switchableTracer(options) {
   const baseTracer = options.baseTracer;
   const tracerStubs = options.tracerStubs;
   const isEnabled = options.isEnabled;
+  const logger = options.logger;
 
   function isProtectedEnabled() {
     try {
       return isEnabled();
-    } catch (_) {
-      // Not much to do with the error but we don't want
-      // to fail; ideally we should log it but the logger might
-      // not be initialized at this point
+    } catch (err) {
+      // Not much to do with the error but we don't want to fail, instead
+      // we will assume it is disabled
+      logger.error('Error determining if tracer is enabled, we will assume it is disabled.', {
+        log_type: 'tracer_is_enabled_error',
+        err
+      });
+
       return false;
     }
   }

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -40,22 +40,7 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
   // also giving us a place to hook additional
   // functionality.
   const wrapSpan = function(srcSpan) {
-    const span = Object.create(srcSpan);
-
-    // Disable baggage.
-    span.getBaggageItem = noop;
-    span.setBaggageItem = noop;
-
-    // Disable logging.
-    span.log = noop;
-
-    // Return our tracer impl instead of
-    // the underlying tracer.
-    span.tracer = function() {
-      return obj;
-    };
-
-    return span;
+    return srcSpan;
   };
 
   obj.startSpan = function(name, spanOptions) {
@@ -135,7 +120,7 @@ module.exports = function Tracer(agent, pkg, env, tracerImpl) {
   };
 
   obj.helpers = {
-    wrapRequest: requestHelper(obj) 
+    wrapRequest: requestHelper(obj)
   };
 
   return obj;

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -80,12 +80,24 @@ module.exports = function Tracer(agent, pkg, env, params) {
   // of features we don't want to use yet, while
   // also giving us a place to hook additional
   // functionality.
-  const wrapSpan = function(srcSpan) {
+  function wrapSpan(srcSpan) {
     return new SpanWrapper(srcSpan, tracer);
   };
 
+  function unwrapSpan(srcSpan) {
+    return srcSpan instanceof SpanWrapper ? srcSpan.getSpan() : srcSpan;
+  }
+
   obj.startSpan = function(name, spanOptions) {
-    return wrapSpan(obj._tracer.startSpan(name, spanOptions));
+    spanOptions = spanOptions || {};
+    const childOf = unwrapSpan(spanOptions.childOf);
+    const references = spanOptions.references;
+    const startTime = spanOptions.startTime;
+    const tags = spanOptions.tags;
+
+    return wrapSpan(obj._tracer.startSpan(name, {
+      childOf, references, startTime, tags
+    }));
   };
 
   // Inject the context required to propagate `spanOrContext` using
@@ -99,6 +111,9 @@ module.exports = function Tracer(agent, pkg, env, params) {
   // var context;
   // tracer.inject(span, tracer.FORMAT_AUTH0_BINARY, (ctx) => { context = ctx });
   obj.inject = function(spanOrContext, format, carrier) {
+    spanOrContext = unwrapSpan(spanOrContext);
+    carrier = unwrapSpan(carrier);
+
     if (format === obj.FORMAT_AUTH0_BINARY) {
       const textCarrier = {};
       obj.inject(spanOrContext, obj.FORMAT_TEXT_MAP, textCarrier);
@@ -113,12 +128,14 @@ module.exports = function Tracer(agent, pkg, env, params) {
         // ignore failures to propagate
       }
     }
-    const unwrappedSpanOrContext = spanOrContext instanceof SpanWrapper ? spanOrContext.getSpan() : spanOrContext;
-    obj._tracer.inject(unwrappedSpanOrContext, format, carrier);
+
+    obj._tracer.inject(spanOrContext, format, carrier);
   };
 
   // Extract span context from a carrier, using the specified format.
   obj.extract = function(format, carrier) {
+    carrier = unwrapSpan(carrier);
+
     if (format === obj.FORMAT_AUTH0_BINARY) {
       // Carrier should be a buffer containing a serialized
       // SpanContext proto, which will we decode, then

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -20,9 +20,9 @@ const Tags = Object.assign({
   AUTH0_CHANNEL: constants.TAG_AUTH0_CHANNEL
 }, tracing.Tags);
 
-module.exports = function Tracer(agent, pkg, env, tracerImpl) {
-
-  const tracer = tracerImpl ? tracerImpl : tracerFactory.create(agent, pkg, env);
+module.exports = function Tracer(agent, pkg, env, params) {
+  params = params || {};
+  const tracer = params.tracerImpl ? params.tracerImpl : tracerFactory.create(agent, pkg, env, { isEnabled: params.isEnabled });
 
   const obj = {
     _tracer: tracer,

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -88,9 +88,12 @@ module.exports = function Tracer(agent, pkg, env, params) {
   }
 
   obj.startSpan = function(name, spanOptions) {
-    const newSpanOptions = Object.assign({}, spanOptions, {
-      childOf: unwrapSpan(spanOptions.childOf)
-    });
+    const wrappedOptions = {}
+    if (spanOptions && spanOptions.childOf) {
+      wrappedOptions.childOf = unwrapSpan(spanOptions.childOf);
+    }
+
+    const newSpanOptions = Object.assign({}, spanOptions, wrappedOptions);
 
     return wrapSpan(obj._tracer.startSpan(name, newSpanOptions));
   };

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -22,36 +22,42 @@ const Tags = Object.assign({
 
 class SpanWrapper {
   constructor(span, tracer) {
-    this.span = span;
-    this.tracer = tracer;
+    this._span = span;
+    this._tracer = tracer;
+  }
+
+  getSpan() {
+    return this._span;
   }
 
   finish(finishTime) {
-    this.span.finish(finishTime);
+    this._span.finish(finishTime);
   }
 
   setTag(key, value) {
-    this.span.finish(key, value);
+    this._span.setTag(key, value);
 
     return this;
   }
 
   addTags(keyValueMap) {
-    this.span.addTags(keyValueMap);
+    this._span.addTags(keyValueMap);
 
     return this;
   }
 
   context() {
-    return this.span.context();
+    return this._span.context();
   }
 
   tracer() {
-    return this;
+    return this._tracer;
   }
 
   setOperationName(name) {
-    return this.span.setOperationName(name);
+    this._span.setOperationName(name);
+
+    return this;
   }
 }
 
@@ -107,7 +113,8 @@ module.exports = function Tracer(agent, pkg, env, params) {
         // ignore failures to propagate
       }
     }
-    obj._tracer.inject(spanOrContext, format, carrier);
+    const unwrappedSpanOrContext = spanOrContext instanceof SpanWrapper ? spanOrContext.getSpan() : spanOrContext;
+    obj._tracer.inject(unwrappedSpanOrContext, format, carrier);
   };
 
   // Extract span context from a carrier, using the specified format.

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -61,8 +61,11 @@ class SpanWrapper {
 
 module.exports = function Tracer(agent, pkg, env, params) {
   params = params || {};
-  const tracer = params.tracerImpl ? params.tracerImpl : tracerFactory.create(agent, pkg, env, { isEnabled: params.isEnabled });
   const logger = params.logger || console;
+  const tracer = params.tracerImpl ? params.tracerImpl : tracerFactory.create(agent, pkg, env, {
+    isEnabled: params.isEnabled,
+    logger
+  });
 
   const obj = {
     _tracer: tracer,
@@ -88,12 +91,12 @@ module.exports = function Tracer(agent, pkg, env, params) {
   }
 
   obj.startSpan = function(name, spanOptions) {
-    const wrappedOptions = {}
+    const unwrappedOptions = {};
     if (spanOptions && spanOptions.childOf) {
-      wrappedOptions.childOf = unwrapSpan(spanOptions.childOf);
+      unwrappedOptions.childOf = unwrapSpan(spanOptions.childOf);
     }
 
-    const newSpanOptions = Object.assign({}, spanOptions, wrappedOptions);
+    const newSpanOptions = Object.assign({}, spanOptions, unwrappedOptions);
 
     return wrapSpan(obj._tracer.startSpan(name, newSpanOptions));
   };
@@ -123,7 +126,13 @@ module.exports = function Tracer(agent, pkg, env, params) {
 
         return carrier(encoded);
       } catch (err) {
-        logger.error('Error injecting from carrier', { spanOrContext, format, carrier, err });
+        logger.error('Error injecting from carrier', {
+          log_type: 'tracing_error_injecting_carrier',
+          spanOrContext,
+          format,
+          carrier,
+          err
+        });
         return;
         // ignore failures to propagate
       }
@@ -144,7 +153,12 @@ module.exports = function Tracer(agent, pkg, env, params) {
         const decoded = SpanContext.decode(carrier);
         return obj.extract(obj.FORMAT_TEXT_MAP, decoded.spanContextMap);
       } catch (err) {
-        logger.error('Error extracting carrier', { format, err, carrier });
+        logger.error('Error extracting carrier', {
+          log_type: 'tracing_error_injecting_carrier',
+          format,
+          err,
+          carrier
+        });
         // ignore decode failures.
         return null;
       }

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -20,6 +20,41 @@ const Tags = Object.assign({
   AUTH0_CHANNEL: constants.TAG_AUTH0_CHANNEL
 }, tracing.Tags);
 
+class SpanWrapper {
+  constructor(span, tracer) {
+    this.span = span;
+    this.tracer = tracer;
+  }
+
+  finish(finishTime) {
+    this.span.finish(finishTime);
+  }
+
+  setTag(key, value) {
+    this.span.finish(key, value);
+
+    return this;
+  }
+
+  addTags(keyValueMap) {
+    this.span.addTags(keyValueMap);
+
+    return this;
+  }
+
+  context() {
+    return this.span.context();
+  }
+
+  tracer() {
+    return this;
+  }
+
+  setOperationName(name) {
+    return this.span.setOperationName(name);
+  }
+}
+
 module.exports = function Tracer(agent, pkg, env, params) {
   params = params || {};
   const tracer = params.tracerImpl ? params.tracerImpl : tracerFactory.create(agent, pkg, env, { isEnabled: params.isEnabled });
@@ -40,7 +75,7 @@ module.exports = function Tracer(agent, pkg, env, params) {
   // also giving us a place to hook additional
   // functionality.
   const wrapSpan = function(srcSpan) {
-    return srcSpan;
+    return new SpanWrapper(srcSpan, tracer);
   };
 
   obj.startSpan = function(name, spanOptions) {

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -7,8 +7,6 @@ const tracing = require('opentracing');
 const tracerFactory = require('./tracer_factory');
 const constants = require('./constants');
 
-const noop = function() {};
-
 const protoRoot = new protobuf.Root();
 protoRoot.loadSync(path.join(__dirname, 'trace_context.proto'));
 const SpanContext = protoRoot.lookupType('auth0.instrumentation.SpanContext');
@@ -64,6 +62,7 @@ class SpanWrapper {
 module.exports = function Tracer(agent, pkg, env, params) {
   params = params || {};
   const tracer = params.tracerImpl ? params.tracerImpl : tracerFactory.create(agent, pkg, env, { isEnabled: params.isEnabled });
+  const logger = params.logger || console;
 
   const obj = {
     _tracer: tracer,
@@ -81,7 +80,7 @@ module.exports = function Tracer(agent, pkg, env, params) {
   // also giving us a place to hook additional
   // functionality.
   function wrapSpan(srcSpan) {
-    return new SpanWrapper(srcSpan, tracer);
+    return srcSpan instanceof SpanWrapper ? srcSpan : new SpanWrapper(srcSpan, tracer);
   };
 
   function unwrapSpan(srcSpan) {
@@ -89,15 +88,11 @@ module.exports = function Tracer(agent, pkg, env, params) {
   }
 
   obj.startSpan = function(name, spanOptions) {
-    spanOptions = spanOptions || {};
-    const childOf = unwrapSpan(spanOptions.childOf);
-    const references = spanOptions.references;
-    const startTime = spanOptions.startTime;
-    const tags = spanOptions.tags;
+    const newSpanOptions = Object.assign({}, spanOptions, {
+      childOf: unwrapSpan(spanOptions.childOf)
+    });
 
-    return wrapSpan(obj._tracer.startSpan(name, {
-      childOf, references, startTime, tags
-    }));
+    return wrapSpan(obj._tracer.startSpan(name, newSpanOptions));
   };
 
   // Inject the context required to propagate `spanOrContext` using
@@ -115,15 +110,17 @@ module.exports = function Tracer(agent, pkg, env, params) {
     carrier = unwrapSpan(carrier);
 
     if (format === obj.FORMAT_AUTH0_BINARY) {
-      const textCarrier = {};
-      obj.inject(spanOrContext, obj.FORMAT_TEXT_MAP, textCarrier);
-      const carrierMsg = SpanContext.create({
-        spanContextMap: textCarrier
-      });
-      const encoded = SpanContext.encode(carrierMsg).finish();
       try {
+        const textCarrier = {};
+        obj.inject(spanOrContext, obj.FORMAT_TEXT_MAP, textCarrier);
+        const carrierMsg = SpanContext.create({
+          spanContextMap: textCarrier
+        });
+        const encoded = SpanContext.encode(carrierMsg).finish();
+
         return carrier(encoded);
       } catch (err) {
+        logger.error('Error injecting from carrier', { spanOrContext, format, carrier, err });
         return;
         // ignore failures to propagate
       }
@@ -143,7 +140,8 @@ module.exports = function Tracer(agent, pkg, env, params) {
       try {
         const decoded = SpanContext.decode(carrier);
         return obj.extract(obj.FORMAT_TEXT_MAP, decoded.spanContextMap);
-      } catch (e) {
+      } catch (err) {
+        logger.error('Error extracting carrier', { format, err, carrier });
         // ignore decode failures.
         return null;
       }

--- a/lib/tracer_factory.js
+++ b/lib/tracer_factory.js
@@ -24,10 +24,14 @@ exports.create = (agent, pkg, env) => {
   }
   if (env.TRACE_AGENT_CLIENT === constants.TRACER_LIGHTSTEP) {
     const lightstepClient = require('lightstep-tracer');
-    const tracer = new lightstepClient.Tracer({
+    const config = {
       access_token: env.TRACE_AGENT_API_KEY,
+      collector_host: env.TRACE_AGENT_HOST,
+      collector_port: env.TRACE_AGENT_PORT,
+      collector_encryption: env.TRACE_AGENT_USE_TLS ? 'tls' : 'none',
       component_name: serviceName
-    });
+    };
+    const tracer = new lightstepClient.Tracer(config);
     return tracer;
   }
   return stubs.tracer;

--- a/lib/tracer_factory.js
+++ b/lib/tracer_factory.js
@@ -1,7 +1,10 @@
 const stubs = require('./stubs');
 const constants = require('./constants');
+const buildSwitchableTracer = require('./switchable_tracer');
 
-exports.create = (agent, pkg, env) => {
+exports.create = (agent, pkg, env, params) => {
+  let tracer = stubs.tracer;
+
   const serviceName = env.SERVICE_NAME || pkg.name;
   if (env.TRACE_AGENT_CLIENT === constants.TRACER_JAEGER) {
     const jaegerClient = require('jaeger-client');
@@ -19,8 +22,7 @@ exports.create = (agent, pkg, env) => {
     };
     const options = { logger: agent.logger };
 
-    const tracer = jaegerClient.initTracer(config, options);
-    return tracer;
+    tracer = jaegerClient.initTracer(config, options);
   }
   if (env.TRACE_AGENT_CLIENT === constants.TRACER_LIGHTSTEP) {
     const lightstepClient = require('lightstep-tracer');
@@ -32,8 +34,16 @@ exports.create = (agent, pkg, env) => {
       component_name: serviceName,
       max_reporting_interval_millis: env.TRACE_REPORTING_INTERVAL_MILLIS || 500
     };
-    const tracer = new lightstepClient.Tracer(config);
-    return tracer;
+    tracer = new lightstepClient.Tracer(config);
   }
-  return stubs.tracer;
+
+  if (typeof params.isEnabled === 'function') {
+    return buildSwitchableTracer({
+      baseTracer: tracer,
+      tracerStubs: stubs.tracer,
+      isEnabled: params.isEnabled
+    });
+  }
+
+  return tracer;
 };

--- a/lib/tracer_factory.js
+++ b/lib/tracer_factory.js
@@ -29,7 +29,8 @@ exports.create = (agent, pkg, env) => {
       collector_host: env.TRACE_AGENT_HOST,
       collector_port: env.TRACE_AGENT_PORT,
       collector_encryption: env.TRACE_AGENT_USE_TLS ? 'tls' : 'none',
-      component_name: serviceName
+      component_name: serviceName,
+      max_reporting_interval_millis: env.TRACE_REPORTING_INTERVAL_MILLIS || 500
     };
     const tracer = new lightstepClient.Tracer(config);
     return tracer;

--- a/lib/tracer_factory.js
+++ b/lib/tracer_factory.js
@@ -41,7 +41,8 @@ exports.create = (agent, pkg, env, params) => {
     return buildSwitchableTracer({
       baseTracer: tracer,
       tracerStubs: stubs.tracer,
-      isEnabled: params.isEnabled
+      isEnabled: params.isEnabled,
+      logger: params.logger
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "datadog-metrics": "^0.3.0",
     "gc-stats": "1.0.2",
     "jaeger-client": "3.12.0",
-    "lightstep-tracer": "ja30278/lightstep-tracer-javascript#a0v2.19.0",
+    "lightstep-tracer": "^0.20.13",
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "moment": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/switchable_tracer.test.js
+++ b/test/switchable_tracer.test.js
@@ -38,7 +38,10 @@ describe('Switchable tracer', () => {
       switchableTracer = buildSwitchableTracer({
         baseTracer: baseTracerMock.mock,
         tracerStubs: tracerStubsMock.mock,
-        isEnabled: () => { throw error; }
+        isEnabled: () => { throw error; },
+        logger: {
+          error: () => {}
+        }
       });
     });
 

--- a/test/switchable_tracer.test.js
+++ b/test/switchable_tracer.test.js
@@ -1,0 +1,167 @@
+const assert = require('assert');
+const buildSwitchableTracer = require('../lib/switchable_tracer');
+
+describe('Switchable tracer', () => {
+  function buildMockTracer(tags) {
+    const startSpanCalls = [];
+    const injectCalls = [];
+    const extractCalls = [];
+
+    return {
+      mock: {
+        startSpan: (name, options) => {
+          startSpanCalls.push({ name, options });
+        },
+        inject: (spanContext, format, carrier) => {
+          injectCalls.push({ spanContext, format, carrier });
+        },
+        extract: (format, carrier) => {
+          extractCalls.push({ format, carrier });
+        },
+        Tags: tags
+      },
+      getResult: () => ({ startSpanCalls, injectCalls, extractCalls })
+    };
+  }
+
+  let switchableTracer;
+  let baseTracerMock;
+  let tracerStubsMock;
+
+  describe('when isEnabled fails', () => {
+    let error = new Error();
+
+    beforeEach(() => {
+      baseTracerMock = buildMockTracer({ base_tracer: true });
+      tracerStubsMock = buildMockTracer({ base_tracer: false });
+
+      switchableTracer = buildSwitchableTracer({
+        baseTracer: baseTracerMock.mock,
+        tracerStubs: tracerStubsMock.mock,
+        isEnabled: () => { throw error; }
+      });
+    });
+
+    it('calls startSpan from stubs', () => {
+      const name = 'name';
+      const options = {};
+      switchableTracer.startSpan(name, options);
+
+      assert.equal(tracerStubsMock.getResult().startSpanCalls[0].name, name);
+      assert.equal(tracerStubsMock.getResult().startSpanCalls[0].options, options);
+      assert.equal(baseTracerMock.getResult().startSpanCalls.length, 0);
+    });
+
+    it('calls inject from stubs', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      const spanContext = {};
+      switchableTracer.inject(spanContext, format, carrier);
+
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].format, format);
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].carrier, carrier);
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].spanContext, spanContext);
+      assert.equal(baseTracerMock.getResult().injectCalls.length, 0);
+    });
+
+    it('calls extract from stubs', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      switchableTracer.extract(format, carrier);
+
+      assert.equal(tracerStubsMock.getResult().extractCalls[0].format, format);
+      assert.equal(tracerStubsMock.getResult().extractCalls[0].carrier, carrier);
+      assert.equal(baseTracerMock.getResult().extractCalls.length, 0);
+    });
+  });
+
+  describe('when tracer is disabled', () => {
+    beforeEach(() => {
+      baseTracerMock = buildMockTracer({ base_tracer: true });
+      tracerStubsMock = buildMockTracer({ base_tracer: false });
+
+      switchableTracer = buildSwitchableTracer({
+        baseTracer: baseTracerMock.mock,
+        tracerStubs: tracerStubsMock.mock,
+        isEnabled: () => false
+      });
+    });
+
+    it('calls startSpan from stubs', () => {
+      const name = 'name';
+      const options = {};
+      switchableTracer.startSpan(name, options);
+
+      assert.equal(tracerStubsMock.getResult().startSpanCalls[0].name, name);
+      assert.equal(tracerStubsMock.getResult().startSpanCalls[0].options, options);
+      assert.equal(baseTracerMock.getResult().startSpanCalls.length, 0);
+    });
+
+    it('calls inject from stubs', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      const spanContext = {};
+      switchableTracer.inject(spanContext, format, carrier);
+
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].format, format);
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].carrier, carrier);
+      assert.equal(tracerStubsMock.getResult().injectCalls[0].spanContext, spanContext);
+      assert.equal(baseTracerMock.getResult().injectCalls.length, 0);
+    });
+
+    it('calls extract from stubs', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      switchableTracer.extract(format, carrier);
+
+      assert.equal(tracerStubsMock.getResult().extractCalls[0].format, format);
+      assert.equal(tracerStubsMock.getResult().extractCalls[0].carrier, carrier);
+      assert.equal(baseTracerMock.getResult().extractCalls.length, 0);
+    });
+  });
+
+  describe('when tracer is enabled', () => {
+    beforeEach(() => {
+      baseTracerMock = buildMockTracer({ base_tracer: true });
+      tracerStubsMock = buildMockTracer({ base_tracer: false });
+
+      switchableTracer = buildSwitchableTracer({
+        baseTracer: baseTracerMock.mock,
+        tracerStubs: tracerStubsMock.mock,
+        isEnabled: () => true
+      });
+    });
+
+    it('calls startSpan from base tracer', () => {
+      const name = 'name';
+      const options = {};
+      switchableTracer.startSpan(name, options);
+
+      assert.equal(baseTracerMock.getResult().startSpanCalls[0].name, name);
+      assert.equal(baseTracerMock.getResult().startSpanCalls[0].options, options);
+      assert.equal(tracerStubsMock.getResult().startSpanCalls.length, 0);
+    });
+
+    it('calls inject from base tracer', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      const spanContext = {};
+      switchableTracer.inject(spanContext, format, carrier);
+
+      assert.equal(baseTracerMock.getResult().injectCalls[0].format, format);
+      assert.equal(baseTracerMock.getResult().injectCalls[0].carrier, carrier);
+      assert.equal(baseTracerMock.getResult().injectCalls[0].spanContext, spanContext);
+      assert.equal(tracerStubsMock.getResult().injectCalls.length, 0);
+    });
+
+    it('calls extract from base tracer', () => {
+      const format = 'format';
+      const carrier = 'carrier';
+      switchableTracer.extract(format, carrier);
+
+      assert.equal(baseTracerMock.getResult().extractCalls[0].format, format);
+      assert.equal(baseTracerMock.getResult().extractCalls[0].carrier, carrier);
+      assert.equal(tracerStubsMock.getResult().extractCalls.length, 0);
+    });
+  });
+});

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -537,8 +537,8 @@ describe('auth0 binary format', function() {
     assert.ok(extracted);
 
     // Verify that the round trip was successful
-    assert.equal(span.uuid(), extracted['uuid']);
-    assert.equal(span.operationName(), extracted['operationName']);
+    assert.equal(span.getSpan().uuid(), extracted.getSpan()['uuid']);
+    assert.equal(span.getSpan().operationName(), extracted.getSpan()['operationName']);
   });
 
   it('should handle bad data', function() {

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -7,13 +7,14 @@ const protobuf = require('protobufjs');
 const request = require('supertest');
 const sinon = require('sinon');
 const requestjs = require('request');
+const stubs = require('../lib/stubs');
 
 describe('tracer stub', function() {
   var $mock;
   var $tracer;
   beforeEach(function() {
     $mock = new opentracing.MockTracer();
-    $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+    $tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: $mock });
   });
 
   describe('when wrapped', function() {
@@ -110,7 +111,7 @@ describe('tracer express middleware', function() {
         carrier['x-span-id'] = span.uuid();
       };
       $mock.extract = sinon.fake();
-      $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+      $tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: $mock });
       app = express();
       app.use($tracer.middleware.express);
       app.get('/success', function(_req, res) {
@@ -216,7 +217,7 @@ describe('tracer express middleware', function() {
         carrier['x-span-id'] = span.uuid();
       };
       $mock.extract = sinon.fake();
-      $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+      $tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: $mock });
       app = express();
       app.use($tracer.middleware.express);
     });
@@ -331,6 +332,24 @@ describe('tracer using jaeger-client', function() {
   });
 });
 
+describe('when using isEnabled is defined', function() {
+  var $tracer;
+  beforeEach(function() {
+    $tracer = require('../lib/tracer')({}, {
+      name: 'auth0-service'
+    }, {
+      TRACE_AGENT_CLIENT: 'jaeger',
+      TRACE_AGENT_HOST: 'jaeger.auth0.net',
+      TRACE_AGENT_PORT: 6831
+    }, { isEnabled: () => {} });
+  });
+
+  it('returns a switchable tracer with correct stubs and base tracer', function() {
+    assert.equal($tracer._tracer.tracerStubs, stubs.tracer);
+    assert.equal($tracer._tracer.baseTracer._process.serviceName, 'auth0-service');
+  });
+});
+
 describe('tracer hapi16 middleware', function() {
   // We expect 4 spans:
   //  - request (top level span)
@@ -348,7 +367,7 @@ describe('tracer hapi16 middleware', function() {
         carrier['x-span-id'] = span.uuid();
       };
       mock.extract = sinon.fake();
-      tracer = require('../lib/tracer')({}, {}, {}, mock);
+      tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: mock });
 
       server = new hapi16.Server();
       server.connection({ port: 9999 });
@@ -500,7 +519,7 @@ describe('auth0 binary format', function() {
         return carrier;
       }
     };
-    $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+    $tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: $mock });
   });
 
   it('should be able to inject and extract using AUTH0_FORMAT', function() {
@@ -523,7 +542,7 @@ describe('auth0 binary format', function() {
   });
 
   it('should handle bad data', function() {
-    assert.doesNotThrow(() => { 
+    assert.doesNotThrow(() => {
       const extracted = $tracer.extract($tracer.FORMAT_AUTH0_BINARY, 'bad data here');
       assert(!extracted);
     });
@@ -558,7 +577,7 @@ describe('trace request helper', function() {
     $mock.inject = function(span, format, carrier) {
       carrier['x-span-id'] = span.uuid();
     };
-    $tracer = require('../lib/tracer')({}, {}, {}, $mock);
+    $tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: $mock });
     $wrapRequest = $tracer.helpers.wrapRequest;
   });
 

--- a/test/tracer.test.js
+++ b/test/tracer.test.js
@@ -295,7 +295,7 @@ describe('tracer using jaeger-client', function() {
     }, {
       TRACE_AGENT_CLIENT: 'jaeger',
       TRACE_AGENT_HOST: 'jaeger.auth0.net',
-      TRACE_AGENT_PORT: 6831
+      TRACE_AGENT_PORT: 443
     });
   });
 
@@ -310,7 +310,7 @@ describe('tracer using jaeger-client', function() {
 
     it('should send spans to the right location', function() {
       assert.equal($tracer._tracer._reporter._sender._host, 'jaeger.auth0.net');
-      assert.equal($tracer._tracer._reporter._sender._port, 6831);
+      assert.equal($tracer._tracer._reporter._sender._port, 443);
     });
 
     it('should contain standard format definitions', function() {
@@ -340,7 +340,7 @@ describe('when using isEnabled is defined', function() {
     }, {
       TRACE_AGENT_CLIENT: 'jaeger',
       TRACE_AGENT_HOST: 'jaeger.auth0.net',
-      TRACE_AGENT_PORT: 6831
+      TRACE_AGENT_PORT: 443
     }, { isEnabled: () => {} });
   });
 

--- a/test/tracer.test.node8.js
+++ b/test/tracer.test.node8.js
@@ -20,7 +20,7 @@ describe('tracer hapi17 middleware', function() {
         carrier['x-span-id'] = span.uuid();
       };
       mock.extract = sinon.fake();
-      tracer = require('../lib/tracer')({}, {}, {}, mock);
+      tracer = require('../lib/tracer')({}, {}, {}, { tracerImpl: mock });
 
       server = new hapi17.Server({port: 9999});
       server.route({

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,7 +911,7 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-google-protobuf@^3.6.1:
+google-protobuf@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
@@ -1057,9 +1057,9 @@ heavy@^4.0.4:
     hoek "4.x.x"
     joi "10.x.x"
 
-hex2dec@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hex2dec/-/hex2dec-1.1.0.tgz#ac98767d3b834f30e8c0cc7b7566f6bb8447922e"
+hex2dec@1.0.1:
+  version "1.0.1"
+  resolved "http://registry.npmjs.org/hex2dec/-/hex2dec-1.0.1.tgz#949bb33f1fdbbeab20e06403a00fc7d5ff284207"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -1339,14 +1339,14 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lightstep-tracer@ja30278/lightstep-tracer-javascript#a0v2.19.0:
-  version "0.20.9"
-  resolved "https://codeload.github.com/ja30278/lightstep-tracer-javascript/tar.gz/96ce0bc651ed6164ce92c1be02bbb48190dc3579"
+lightstep-tracer@^0.20.13:
+  version "0.20.13"
+  resolved "https://registry.yarnpkg.com/lightstep-tracer/-/lightstep-tracer-0.20.13.tgz#7527e24a344f3fae6ea3e46f5fdcd8105e6fab6d"
   dependencies:
     async "1.5.0"
     eventemitter3 "1.1.1"
-    google-protobuf "^3.6.1"
-    hex2dec "^1.0.1"
+    google-protobuf "3.6.1"
+    hex2dec "1.0.1"
     source-map-support "0.3.3"
     thrift "0.10.0"
 


### PR DESCRIPTION
### What?
This PR fixes several issues around tracing and adds a feature to disable tracer completely.
- Fix configuration for Lightstep
- Fix memory leak around span wrapping: the main issue was not the wrapping itself or the associated object creation (although I changed it a bit for a bit of optimisation), the main problem seems to be around the handling of those wrapped objects by the tracing client; specially important regarding the child span. Because of that I decided to wrap and unwrap instead of feeding the client with the wrapped objects.

### Why?
To be able to implement tracing in our services; previous implementation presented problems that were detected during testing.