### PR TITLE
DF-94 Fix error in metrics' flush method when Datadog and StatsD are both configured

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -77,7 +77,7 @@ module.exports = function (pkg, env) {
   };
 
   obj.flush = function () {
-    if (env.METRICS_API_KEY) {
+    if (!env.STATSD_HOST) {
       return metrics.flush();
     }
     // STATSD does not require flush.


### PR DESCRIPTION
When running a cert rollover job, we've been getting an error when the `metrics.flush()` method is called. 

```
TypeError: metrics.flush is not a function
    at Object.obj.flush (/usr/local/lib/node_modules/auth0-notifications/node_modules/auth0-instrumentation/lib/metrics.js:51:22)
    at Object.flush (/usr/local/lib/node_modules/auth0-notifications/lib/jobs/certs_rollover/metrics.js:55:19)
    at /usr/local/lib/node_modules/auth0-notifications/lib/jobs/certs_rollover/index.js:43:13
```

It appears that if both `STATSD_HOST` and `METRICS_API_KEY` are defined, StatsD is set up but we still try to call a `flush()` method (which doesn't exist). 