### PR TITLE
Add region/environment/channel tags to sentry events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+<a name="v2.21.0"></a>
+# v2.21.0
+### Feature
+* Add `region`/`environment`/`channel` tags to sentry events
+* https://github.com/auth0/auth0-instrumentation/compare/v2.20.1...v2.21.0
+
 <a name="v2.20.1"></a>
 # v2.20.1
 ### Bugfix

--- a/lib/auth0_sentry_stream.js
+++ b/lib/auth0_sentry_stream.js
@@ -4,6 +4,13 @@ const omit = require('lodash.omit');
 
 // // //
 
+const TAGS_WHITELIST = [
+  'log_type',
+  'region',
+  'environment',
+  'channel'
+];
+
 /**
  * Auth0-specific Sentry stream for Bunyan, forked from https://github.com/transcovo/bunyan-sentry-stream/blob/bf4a9d2262b7854aff6eb757b45565abc664e103/lib/SentryStream.js.
  */
@@ -28,9 +35,11 @@ class Auth0SentryStream {
     const tags = record.tags || { };
     const level = this.getSentryLevel(record);
 
-    if (record.hasOwnProperty('log_type')) {
-      tags.log_type = record.log_type;
-    }
+    TAGS_WHITELIST.forEach((tag) => {
+      if (record[tag]) {
+        tags[tag] = record[tag];
+      }
+    });
 
     if (err && level !== 'info') {
       const extra = omit(record, 'err', 'tags');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.20.1",
+  "version": "2.21.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These values were already available in the `extra` attributes, but tags are useful in the Sentry UI (ex. to filter events and to have these values visible in slack notifications).
See: https://docs.sentry.io/enriching-error-data/context/?platform=javascript#tagging-events

Discussed: https://auth0.slack.com/archives/CB3H1QLA1/p1541613538015400