### PR TITLE
AppMetrics: Runtime Investigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,17 +10,50 @@ agent.init({name: 'test'}, process.env);
 const monitor = appmetrics.monitor();
 agent.metrics.startRuntimeCollection(appmetrics, monitor);
 
+var MongoClient = require('mongodb').MongoClient;
+var db;
+
 const express = require('express');
 const app = express();
 const port = 3000;
 
-app.get('/', (req, res) => {
-  agent.metrics.incrementOne('http.request');
-  res.send('Hello World!');
+app.post(
+  '/debug/v8/profiling',
+  new agent.http.DebugRuntimeToggle('profiling', appmetrics).toggle
+);
+
+app.post(
+  '/debug/mongodb',
+  new agent.http.DebugRuntimeToggle('mongodb', appmetrics).toggle
+);
+
+app.post(
+  '/debug/trace',
+  new agent.http.DebugRuntimeToggle('trace', appmetrics).toggle
+);
+
+app.post(
+  '/debug/requests',
+  new agent.http.DebugRuntimeToggle('requests', appmetrics).toggle
+);
+
+// Connect to the db
+MongoClient.connect("mongodb://localhost:27017", function(err, client) {
+  if(!err) {
+    console.log("We are connected");
+  }
+
+  db = client.db('test');
+
+  app.get('/', (req, res) => {
+    db.collection('test1').find({}, (err, result) => {
+      agent.metrics.incrementOne('http.request');
+      // console.log(err);
+      // console.log(result);
+      res.send('Hello World!');
+    });
+  });
+
+  app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 });
 
-const profileHTTP = new agent.http.DebugRuntimeToggle('profiling', monitor);
-
-app.post('/debug/v8/profiling', profileHTTP.toggle);
-
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/app.js
+++ b/app.js
@@ -1,9 +1,13 @@
 const appmetrics = require('appmetrics');
 const agent = require('./index.js');
 
+if (process.env.INSTRUMENTATION_ATTACH_APPMETRICS_DASH) {
+  require('appmetrics-dash').attach();
+}
+
 appmetrics.configure({
   mqtt: 'off',
-  profiling: 'off'
+  profiling: 'off',
 });
 
 agent.init({name: 'test'}, process.env);

--- a/app.js
+++ b/app.js
@@ -37,6 +37,11 @@ app.post(
   new agent.http.DebugRuntimeToggle('requests', appmetrics).toggle
 );
 
+app.post(
+  '/debug/loop',
+  new agent.http.DebugRuntimeToggle('loop', appmetrics).toggle
+);
+
 // Connect to the db
 MongoClient.connect("mongodb://localhost:27017", function(err, client) {
   if(!err) {

--- a/app.js
+++ b/app.js
@@ -7,12 +7,20 @@ appmetrics.configure({
 });
 
 agent.init({name: 'test'}, process.env);
-agent.metrics.startRuntimeCollection(appmetrics);
+const monitor = appmetrics.monitor();
+agent.metrics.startRuntimeCollection(appmetrics, monitor);
 
 const express = require('express');
 const app = express();
 const port = 3000;
 
-app.get('/', (req, res) => res.send('Hello World!'));
+app.get('/', (req, res) => {
+  agent.metrics.incrementOne('http.request');
+  res.send('Hello World!');
+});
+
+const profileHTTP = new agent.http.DebugRuntimeToggle('profiling', monitor);
+
+app.post('/debug/v8/profiling', profileHTTP.toggle);
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/app.js
+++ b/app.js
@@ -1,0 +1,18 @@
+const appmetrics = require('appmetrics');
+const agent = require('./index.js');
+
+appmetrics.configure({
+  mqtt: 'off',
+  profiling: 'off'
+});
+
+agent.init({name: 'test'}, process.env);
+agent.metrics.startRuntimeCollection(appmetrics);
+
+const express = require('express');
+const app = express();
+const port = 3000;
+
+app.get('/', (req, res) => res.send('Hello World!'));
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var ErrorReporter = require('./lib/error_reporter');
 var Metrics = require('./lib/metrics');
 var Profiler = require('./lib/profiler');
 var Tracer = require('./lib/tracer');
+var MetricsHTTP = require('./lib/metrics/http');
 
 module.exports = {
   logger: stubs.logger,
@@ -32,5 +33,7 @@ module.exports = {
         this.logger.info('The log file has been rotated.');
       });
     }
+
+    this.http = MetricsHTTP;
   }
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -192,7 +192,14 @@ module.exports = function (pkg, env) {
 
 
     monitor.on('mongo', (data) => {
-      console.log(data);
+      obj.histogram(
+        'mongo.query.duration.ms',
+        data.duration,
+        Object.assign({
+          collection: data.collection,
+          method: data.method
+        }, tags)
+      );
     });
 
     monitor.on('trace', (data) => {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -195,6 +195,10 @@ module.exports = function (pkg, env) {
       console.log(data);
     });
 
+    monitor.on('trace', (data) => {
+      console.log(data);
+    });
+
     monitor.on('requests', (data) => {
       console.log('requests');
       console.log(data);

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -206,7 +206,7 @@ module.exports = function (pkg, env) {
       console.log(data);
     });
 
-    monitor.on('requests', (data) => {
+    monitor.on('request', (data) => {
       console.log('requests');
       console.log(data);
     });

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -143,7 +143,7 @@ module.exports = function (pkg, env) {
       'profiling',
       'http',
       'http-outbound',
-      'mongo',
+      'mongodb',
       'socketio',
       'mqlight',
       'postgresql',
@@ -192,6 +192,11 @@ module.exports = function (pkg, env) {
 
 
     monitor.on('mongo', (data) => {
+      console.log(data);
+    });
+
+    monitor.on('requests', (data) => {
+      console.log('requests');
       console.log(data);
     });
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -130,5 +130,60 @@ module.exports = function (pkg, env) {
     });
   };
 
+  obj.startRuntimeCollection = (appmetrics, tags) => {
+    if (!env.INSTRUMENTATION_COLLECT_RUNTIME_STATS) {
+      return;
+    }
+
+    const monitor = appmetrics.monitor();
+
+    tags = tags || {};
+
+    const DISABLED_METRICS = [
+      'eventloop',
+      'profiling',
+      'http',
+      'http-outbound',
+      'mongo',
+      'socketio',
+      'mqlight',
+      'postgresql',
+      'mqtt',
+      'mysql',
+      'redis',
+      'riak',
+      'memcached',
+      'oracledb',
+      'oracle',
+      'strong-oracle',
+      'requests',
+      'trace'
+    ];
+    DISABLED_METRICS.map(appmetrics.disable);
+
+    const ENABLED_METRICS = ['eventloop', 'loop'];
+    ENABLED_METRICS.map(appmetrics.enable);
+
+    monitor.on('loop', (stats) => {
+      console.log(stats);
+      agent.metrics.gauge('runtime.loop.ticks', stats.count, tags);
+      agent.metrics.gauge('runtime.loop.cpu_user', stats.cpu_user, tags);
+      agent.metrics.gauge('runtime.loop.cpu_system', stats.cpu_system, tags);
+      agent.metrics.gauge('runtime.loop.tick.latency.min.ms', stats.minimum, tags);
+      agent.metrics.gauge('runtime.loop.tick.latency.max.ms', stats.maximum, tags);
+      agent.metrics.gauge('runtime.loop.tick.latency.avg.ms', stats.average, tags);
+    });
+
+    monitor.on('eventloop', (stats) => {
+      console.log(stats);
+
+      agent.metrics.gauge('runtime.loop.latency.min.ms', stats.latency.min, tags);
+      agent.metrics.gauge('runtime.loop.latency.max.ms', stats.latency.max, tags);
+      agent.metrics.gauge('runtime.loop.latency.avg.ms', stats.latency.avg, tags);
+
+    });
+
+  };
+
   return obj;
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -131,12 +131,10 @@ module.exports = function (pkg, env) {
     });
   };
 
-  obj.startRuntimeCollection = (appmetrics, tags) => {
+  obj.startRuntimeCollection = (appmetrics, monitor, tags) => {
     if (!env.INSTRUMENTATION_COLLECT_RUNTIME_STATS) {
       return;
     }
-
-    const monitor = appmetrics.monitor();
 
     tags = tags || {};
 
@@ -178,6 +176,23 @@ module.exports = function (pkg, env) {
       obj.gauge('runtime.loop.latency.min.ms', stats.latency.min, tags);
       obj.gauge('runtime.loop.latency.max.ms', stats.latency.max, tags);
       obj.gauge('runtime.loop.latency.avg.ms', stats.latency.avg, tags);
+    });
+
+    monitor.on('gc', (data) => {
+      obj.gauge(
+        'runtime.gc.duration.ms',
+        data.duration,
+        Object.assign({gc_type: data.type}, tags)
+      );
+    });
+
+    monitor.on('profiling', (data) => {
+      console.log(data);
+    });
+
+
+    monitor.on('mongo', (data) => {
+      console.log(data);
     });
 
   };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -8,6 +8,7 @@ const stubs = require('./stubs').metrics;
 
 module.exports = function (pkg, env) {
   if (!env.STATSD_HOST && !env.METRICS_API_KEY) {
+    console.log('returning stub');
     return stubs;
   }
 
@@ -165,22 +166,18 @@ module.exports = function (pkg, env) {
     ENABLED_METRICS.map(appmetrics.enable);
 
     monitor.on('loop', (stats) => {
-      console.log(stats);
-      agent.metrics.gauge('runtime.loop.ticks', stats.count, tags);
-      agent.metrics.gauge('runtime.loop.cpu_user', stats.cpu_user, tags);
-      agent.metrics.gauge('runtime.loop.cpu_system', stats.cpu_system, tags);
-      agent.metrics.gauge('runtime.loop.tick.latency.min.ms', stats.minimum, tags);
-      agent.metrics.gauge('runtime.loop.tick.latency.max.ms', stats.maximum, tags);
-      agent.metrics.gauge('runtime.loop.tick.latency.avg.ms', stats.average, tags);
+      obj.gauge('runtime.loop.ticks', stats.count, tags);
+      obj.gauge('runtime.loop.cpu_user', stats.cpu_user, tags);
+      obj.gauge('runtime.loop.cpu_system', stats.cpu_system, tags);
+      obj.gauge('runtime.loop.tick.latency.min.ms', stats.minimum, tags);
+      obj.gauge('runtime.loop.tick.latency.max.ms', stats.maximum, tags);
+      obj.gauge('runtime.loop.tick.latency.avg.ms', stats.average, tags);
     });
 
     monitor.on('eventloop', (stats) => {
-      console.log(stats);
-
-      agent.metrics.gauge('runtime.loop.latency.min.ms', stats.latency.min, tags);
-      agent.metrics.gauge('runtime.loop.latency.max.ms', stats.latency.max, tags);
-      agent.metrics.gauge('runtime.loop.latency.avg.ms', stats.latency.avg, tags);
-
+      obj.gauge('runtime.loop.latency.min.ms', stats.latency.min, tags);
+      obj.gauge('runtime.loop.latency.max.ms', stats.latency.max, tags);
+      obj.gauge('runtime.loop.latency.avg.ms', stats.latency.avg, tags);
     });
 
   };

--- a/lib/metrics/http.js
+++ b/lib/metrics/http.js
@@ -2,16 +2,16 @@
 
 
 class DebugRuntimeToggle {
-  constructor(metricType, monitor) {
+  constructor(metricType, appmetrics) {
     this.metricType = metricType;
-    this.monitor = monitor;
+    this.appmetrics = appmetrics;
     this.enabled = false;
     this.toggle = this.toggle.bind(this);
   }
 
   toggle(req, res) {
     const action = (this.enabled) ? 'disable' : 'enable';
-    this.monitor[action](this.metricType);
+    this.appmetrics[action](this.metricType);
     res.send({
       action: action,
       metricType: this.metricType,

--- a/lib/metrics/http.js
+++ b/lib/metrics/http.js
@@ -1,0 +1,25 @@
+
+
+
+class DebugRuntimeToggle {
+  constructor(metricType, monitor) {
+    this.metricType = metricType;
+    this.monitor = monitor;
+    this.enabled = false;
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle(req, res) {
+    const action = (this.enabled) ? 'disable' : 'enable';
+    this.monitor[action](this.metricType);
+    res.send({
+      action: action,
+      metricType: this.metricType,
+    });
+    this.enabled = !this.enabled;
+  }
+}
+
+module.exports = {
+  DebugRuntimeToggle: DebugRuntimeToggle,
+};

--- a/lib/metrics_factory.js
+++ b/lib/metrics_factory.js
@@ -3,6 +3,7 @@ const StatsD = require('node-statsd');
 const datadog = require('datadog-metrics');
 
 function buildStatsD(pkg, env) {
+  console.log('initializing statsd');
   const parsedURL = url.parse(env.STATSD_HOST);
   return new StatsD({
     host: parsedURL.hostname,
@@ -13,6 +14,7 @@ function buildStatsD(pkg, env) {
 }
 
 function buildDataDog(pkg, env) {
+  console.log('initializing datadog');
   return new datadog.BufferedMetricsLogger({
     apiKey: env.METRICS_API_KEY,
     host: env.METRICS_HOST || require('os').hostname(),

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -58,6 +58,7 @@ const emptyMetrics = {
   flush: noop,
   setDefaultTags: noop,
   startResourceCollection: noop,
+  startRuntimeCollection: noop,
   time: returnValue,
   endTime: noop,
   callback: noop

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "moment": "^2.18.1",
+    "mongo": "^0.1.0",
     "ms": "^2.0.0",
     "node-statsd": "^0.1.1",
     "on-finished": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Auth0",
   "license": "ISC",
   "dependencies": {
+    "appmetrics": "^4.0.1",
     "auth0-common-logging": "auth0/auth0-common-logging#v2.18.0",
     "aws-kinesis-writable": "4.2.0",
     "blocked": "^1.2.1",

--- a/vivaldi/grafana/mongodb.dashboard.json
+++ b/vivaldi/grafana/mongodb.dashboard.json
@@ -1,0 +1,161 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prom",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "test_mongo_query_duration_ms_mean",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "host:{{host}} - method:{{ method }} - collection:{{ collection }}",
+          "refId": "A"
+        },
+        {
+          "expr": "test_mongo_query_duration_ms_lower",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "host:{{host}} - method:{{ method }} - collection:{{ collection }}",
+          "refId": "B"
+        },
+        {
+          "expr": "test_mongo_query_duration_ms_upper",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "host:{{host}} - method:{{ method }} - collection:{{ collection }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mongo Queries",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Mongo Queries",
+  "uid": null,
+  "version": 0
+}

--- a/vivaldi/grafana/runtime.dashboard.json
+++ b/vivaldi/grafana/runtime.dashboard.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -23,7 +23,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": "Prom",
       "description": "the number of event loop ticks in the last interval.",
       "fill": 1,
       "gridPos": {
@@ -56,6 +56,8 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "test_runtime_loop_ticks",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -70,6 +72,7 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
           "measurement": "test_runtime_loop_ticks",
           "orderByTime": "ASC",
           "policy": "default",
@@ -138,7 +141,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": "Prom",
       "description": "Summarising sample based information of the event loop latency",
       "fill": 1,
       "gridPos": {
@@ -171,6 +174,8 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "test_runtime_loop_latency_avg_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -185,6 +190,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - avg",
           "measurement": "test_runtime_loop_latency_avg_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -207,6 +214,8 @@
           "tags": []
         },
         {
+          "expr": "test_runtime_loop_latency_min_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -221,6 +230,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - min",
           "measurement": "test_runtime_loop_latency_max_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -243,6 +254,8 @@
           "tags": []
         },
         {
+          "expr": "test_runtime_loop_latency_max_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -257,6 +270,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - max",
           "measurement": "test_runtime_loop_latency_min_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -325,7 +340,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": "Prom",
       "description": "summarising event tick information(latency) in time interval",
       "fill": 1,
       "gridPos": {
@@ -358,6 +373,8 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "test_runtime_loop_tick_latency_avg_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -372,6 +389,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - avg",
           "measurement": "test_runtime_loop_tick_latency_avg_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -394,6 +413,8 @@
           "tags": []
         },
         {
+          "expr": "test_runtime_loop_tick_latency_max_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -408,6 +429,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - max",
           "measurement": "test_runtime_loop_tick_latency_max_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -430,6 +453,8 @@
           "tags": []
         },
         {
+          "expr": "test_runtime_loop_tick_latency_min_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -444,6 +469,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "{{ host }} - min",
           "measurement": "test_runtime_loop_tick_latency_min_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -512,7 +539,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": "Prom",
       "description": "the percentage of 1 CPU used by the event loop thread",
       "fill": 1,
       "gridPos": {
@@ -545,6 +572,8 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "test_runtime_loop_cpu_system",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -559,6 +588,7 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
           "measurement": "test_runtime_loop_cpu_system",
           "orderByTime": "ASC",
           "policy": "default",
@@ -581,6 +611,8 @@
           "tags": []
         },
         {
+          "expr": "test_runtime_loop_cpu_user",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -595,6 +627,7 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
           "measurement": "test_runtime_loop_cpu_user",
           "orderByTime": "ASC",
           "policy": "default",
@@ -663,7 +696,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": "Prom",
       "description": "Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime.\n\ntype (String) the type of GC cycle, either:\n'M': MarkSweepCompact, aka \"major\"\n'S': Scavenge, aka \"minor\"\n'I': IncrementalMarking, aka \"incremental\" (only exists on node 5.x and greater)\n'W': ProcessWeakCallbacks, aka \"weakcb\" (only exists on node 5.x and greater)",
       "fill": 1,
       "gridPos": {
@@ -696,6 +729,8 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "test_runtime_gc_duration_ms",
+          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -716,6 +751,8 @@
               "type": "fill"
             }
           ],
+          "intervalFactor": 1,
+          "legendFormat": "Type: {{ gc_type }} - {{ host }}",
           "measurement": "test_runtime_gc_duration_ms",
           "orderByTime": "ASC",
           "policy": "default",
@@ -819,5 +856,5 @@
   "timezone": "",
   "title": "Node.js Runtime",
   "uid": "--bjLEEiz",
-  "version": 2
+  "version": 1
 }

--- a/vivaldi/grafana/runtime.dashboard.json
+++ b/vivaldi/grafana/runtime.dashboard.json
@@ -1,0 +1,823 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "description": "the number of event loop ticks in the last interval.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_ticks",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Event Loop Ticks",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "description": "Summarising sample based information of the event loop latency",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_latency_avg_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_latency_max_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_latency_min_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "EventLoop Latency - Sampled",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "description": "summarising event tick information(latency) in time interval",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_tick_latency_avg_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_tick_latency_max_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_tick_latency_min_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Event Tick Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "description": "the percentage of 1 CPU used by the event loop thread",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_cpu_system",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_loop_cpu_user",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Event Loop Tick CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "description": "Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime.\n\ntype (String) the type of GC cycle, either:\n'M': MarkSweepCompact, aka \"major\"\n'S': Scavenge, aka \"minor\"\n'I': IncrementalMarking, aka \"incremental\" (only exists on node 5.x and greater)\n'W': ProcessWeakCallbacks, aka \"weakcb\" (only exists on node 5.x and greater)",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "gc_type"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_runtime_gc_duration_ms",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "GC Collection Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Node.js Runtime",
+  "uid": "--bjLEEiz",
+  "version": 2
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,6 +362,11 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+bson@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
+  integrity sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==
+
 buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
@@ -1672,6 +1677,11 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memory-pager@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.3.1.tgz#1153d2f5e157a407a436bf54ccf4139037515866"
+  integrity sha512-pUf/sGkym2WqFZYTVmdASnSbNfpGc9rwxEHOePx4lT/fD+NHGL1U16Uy4o6PMiVcDv4mp6MI/vaF0c/Kd1QEUQ==
+
 merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -1795,6 +1805,32 @@ module-not-found-error@^1.0.0:
 moment@2.x.x, moment@^2.10.6, moment@^2.18.1:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
+
+mongo@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/mongo/-/mongo-0.1.0.tgz#c8af0f8df98d4894b772b37342987c3becf3718c"
+  integrity sha1-yK8PjfmNSJS3crNzQph8O+zzcYw=
+  dependencies:
+    mongodb "*"
+
+mongodb-core@3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.9.tgz#c31ee407bf932b0149eaed775c17ee09974e4ca3"
+  integrity sha512-MJpciDABXMchrZphh3vMcqu8hkNf/Mi+Gk6btOimVg1XMxLXh87j6FAvRm+KmwD1A9fpu3qRQYcbQe4egj23og==
+  dependencies:
+    bson "^1.1.0"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@*:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.10.tgz#45ad9b74ea376f4122d0881b75e5489b9e504ed7"
+  integrity sha512-Uml42GeFxhTGQVml1XQ4cD0o/rp7J2ROy0fdYUcVitoE7vFqEhKH4TYVqRDpQr/bXtCJVxJdNQC1ntRxNREkPQ==
+  dependencies:
+    mongodb-core "3.1.9"
+    safe-buffer "^5.1.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2425,6 +2461,19 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
+
 resolve@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -2463,6 +2512,13 @@ samsam@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
+saslprep@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.2.tgz#da5ab936e6ea0bbae911ffec77534be370c9f52d"
+  integrity sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -2474,6 +2530,11 @@ sax@>=0.6.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.1.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 semver@~4.3.3:
   version "4.3.6"
@@ -2587,6 +2648,13 @@ source-map@0.1.32:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
   dependencies:
     amdefine ">=0.0.4"
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
 
 spdx-correct@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,13 @@ agent-base@2:
     extend "~3.0.0"
     semver "~5.0.1"
 
+agent-base@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -145,6 +152,17 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+appmetrics@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/appmetrics/-/appmetrics-4.0.1.tgz#2a7d9389f1c266bdf0b16ab9af2d7ea10bb12fc4"
+  integrity sha512-lnsnvu2Q95OIZ/blel+RgiGj5KURknDbWEaYuWD5w+RQyUhAH/SaVAsaoqchcq7gjTtmK5XsY8dEAgHKkAwCeA==
+  dependencies:
+    ibmapm-embed "^1.0.0"
+    jszip "2.5.x"
+    nan "2.x"
+    semver "^5.3.0"
+    tar "4.x"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -155,6 +173,13 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -175,6 +200,13 @@ assert-plus@^0.2.0:
 async@1.5.0:
   version "1.5.0"
   resolved "http://registry.npmjs.org/async/-/async-1.5.0.tgz#2796642723573859565633fc6274444bee2f8ce3"
+
+async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  dependencies:
+    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -426,6 +458,11 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -599,6 +636,13 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -678,6 +722,38 @@ error@7.0.2, error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
+es-abstract@^1.5.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
+es6-promise@^4.0.3:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
+  integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -685,6 +761,11 @@ escape-html@~1.0.3:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -826,6 +907,13 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -846,6 +934,11 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1018,9 +1111,21 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -1122,6 +1227,36 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
+ibmapm-embed@^1.0.0:
+  version "1.0.41"
+  resolved "https://registry.yarnpkg.com/ibmapm-embed/-/ibmapm-embed-1.0.41.tgz#1b575ba592cf3461470f2ed10ad3fbcb20efd369"
+  integrity sha512-yw4Lcb5FLq58zo1vwIpwQkZH4Mv40RucOEDNgO8Y8sVVZ+ZOVLJyhRTDGo2q/ZxzVohvRW3AcB8ek4j7qKjbmA==
+  dependencies:
+    ibmapm-restclient "^1.0.0"
+    log4js "^0.6.38"
+    properties "^1.2.1"
+    uuid "^2.0.2"
+
+ibmapm-restclient@^1.0.0:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/ibmapm-restclient/-/ibmapm-restclient-1.0.34.tgz#a302d49fff842a5858ed2a118e0f54f0bd89b97b"
+  integrity sha512-rkXuVCbbX+IR2qD1xaNriX3MsWx2r9g+n8PHw9P7lBC6ARn+ZHmyFiCICf95ENw2qh4Py/Xzzi33F/DaeXX0eg==
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    kubernetes-client "^3.16.0"
+    log4js "^0.6.38"
+    properties "^1.2.1"
+    request "^2.72.0"
+    uuid "^2.0.2"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -1141,7 +1276,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1183,6 +1318,16 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.3, is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -1197,9 +1342,23 @@ is-object@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1287,6 +1446,14 @@ joi@^6.9.1:
     moment "2.x.x"
     topo "1.x.x"
 
+js-yaml@^3.10.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1333,9 +1500,27 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jszip@2.5.x:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-2.5.0.tgz#7444fd8551ddf3e5da7198fea0c91bc8308cc274"
+  integrity sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=
+  dependencies:
+    pako "~0.2.5"
+
 just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
+kubernetes-client@^3.16.0:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/kubernetes-client/-/kubernetes-client-3.18.1.tgz#a72ebb4c8be1ef6648df3b2da2223b5b3d92d516"
+  integrity sha512-6sS9osVL8RvzAwblnAeWc8gdeD0WQ2g9NytscCV7i5H3rJ4ptCXZW1xOMFbMRkW3zMUS4Elg/Z0f+0hUqSiqMw==
+  dependencies:
+    async "^2.6.0"
+    js-yaml "^3.10.0"
+    lodash.merge "^4.6.0"
+    request "^2.83.0"
+    util.promisify "^1.0.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -1421,7 +1606,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.merge@^4.6.1:
+lodash.merge@^4.6.0, lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
@@ -1437,9 +1622,22 @@ lodash@^4.0.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@~3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+log4js@^0.6.38:
+  version "0.6.38"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-0.6.38.tgz#2c494116695d6fb25480943d3fc872e662a522fd"
+  integrity sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=
+  dependencies:
+    readable-stream "~1.0.2"
+    semver "~4.3.3"
 
 lolex@^2.3.2, lolex@^2.7.1:
   version "2.7.1"
@@ -1552,7 +1750,22 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.1:
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
+  dependencies:
+    minipass "^2.2.1"
+
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1599,14 +1812,14 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.3.3, nan@^2.5.1:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-
-nan@^2.6.2:
+nan@2.x, nan@^2.6.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
+
+nan@^2.3.3, nan@^2.5.1:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nan@~1.0.0:
   version "1.0.0"
@@ -1759,6 +1972,19 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -1825,6 +2051,11 @@ p-locate@^2.0.0:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+pako@~0.2.5:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -1922,6 +2153,11 @@ podium@^1.3.0:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+properties@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/properties/-/properties-1.2.1.tgz#0ee97a7fc020b1a2a55b8659eda4aa8d869094bd"
+  integrity sha1-Dul6f8AgsaKlW4ZZ7aSqjYaQlL0=
 
 protobufjs@^6.8.8:
   version "6.8.8"
@@ -2064,6 +2300,16 @@ readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@~1.0.2:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -2146,7 +2392,7 @@ request@^2.27.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.88.0:
+request@^2.72.0, request@^2.83.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -2228,6 +2474,11 @@ sax@>=0.6.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@~4.3.3:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+  integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
 semver@~5.0.1:
   version "5.0.3"
@@ -2359,6 +2610,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
 sshpk@^1.7.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
@@ -2425,6 +2681,11 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -2540,6 +2801,19 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
+tar@4.x:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -2647,6 +2921,14 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -2654,6 +2936,11 @@ utils-merge@1.0.1:
 uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
@@ -2786,6 +3073,11 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
```
$ INSTRUMENTATION_COLLECT_RUNTIME_STATS=1 STATSD_HOST=udp://localhost:8125 METRICS_API_KEY=x node app.js
```

## Contents
- Runtime metrics for event loop, Event tick, and GC
- Dynamic V8 Profiling
- MongoDB query tracing


## Vivaldi dashboard for local testing

<img width="1275" alt="screen shot 2018-12-14 at 9 51 54 am" src="https://user-images.githubusercontent.com/321963/50009832-f7ec6c80-ff85-11e8-8afc-25024ffe73db.png">


## MongoDB query tracing
- Enabled mongo query tracing
```
$ curl -X POST localhost:3000/debug/mongodb
{"action":"enable","metricType":"mongodb"}
```
- queries are logged
```
{ time: 1544733403108,
  query: '{}',
  duration: 5.179234,
  method: 'find',
  collection: 'test1',
  count: undefined }
```

## V8 Profiling
- start the service
- enable or disable by posting to debug endpoint
```
$ curl -X POST localhost:3000/debug/v8/profiling
{"action":"enable","metricType":"profiling"}
```
- disable
```
$ curl -X POST localhost:3000/debug/v8/profiling
{"action":"disable","metricType":"profiling"}
```
- Results can be viewed as a flame graph in appmetrics dashboard
<img width="1382" alt="screen shot 2018-12-14 at 1 13 51 pm" src="https://user-images.githubusercontent.com/321963/50020786-0bf39680-ffa5-11e8-8fb8-fb1190f6aa26.png">


# Demos

## Show Runtime Metrics
- Start Statsd stack
- Load the runtime dashboard
- Start the server with runtime instrumentation enabled
```
$ INSTRUMENTATION_COLLECT_RUNTIME_STATS=1 SERVICE_NAME=builtin STATSD_HOST=udp://localhost:8125 METRICS_API_KEY=x node app.js
```
- Apply Load
```
$ echo "GET http://localhost:3000/" | vegeta attack -rate 1 -duration=0 | tee results.bin | vegeta report
```

## Show Mongo Tracing
- Start statsd stack
- load the mongo dashboard
- start the server with runtime instrumentation enabled
```
$ INSTRUMENTATION_COLLECT_RUNTIME_STATS=1 SERVICE_NAME=builtin STATSD_HOST=udp://localhost:8125 METRICS_API_KEY=x node app.js
```
- Enable mongo tracing
```
$ curl -X POST localhost:3000/debug/mongodb
```
- Apply Load
```
$ echo "GET http://localhost:3000/" | vegeta attack -rate 1 -duration=0 | tee results.bin | vegeta report
```

## Show dynamic v8 profiling
- start the server with app metrics dashboard and  instrumentation enabled
```
INSTRUMENTATION_ATTACH_APPMETRICS_DASH=1 INSTRUMENTATION_COLLECT_RUNTIME_STATS=1 SERVICE_NAME=builtin STATSD_HOST=udp://localhost:8125 METRICS_API_KEY=x node app.js
```
- Navigate to appmetrics dash
```
$ http://localhost:3000/appmetrics-dash/
```
- Click enable profiling