### PR TITLE
Tracing: spanWrap passes tracer abstraction in order to pass Tags

### DIFF
--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -91,7 +91,7 @@ module.exports = function Tracer(agent, pkg, env, params) {
   // also giving us a place to hook additional
   // functionality.
   function wrapSpan(srcSpan) {
-    return srcSpan instanceof SpanWrapper ? srcSpan : new SpanWrapper(srcSpan, tracer);
+    return srcSpan instanceof SpanWrapper ? srcSpan : new SpanWrapper(srcSpan, obj);
   };
 
   function unwrapSpan(srcSpan) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
refs #WOLF-394
## Overview

There was an issue starting spans more than a single layer deep.  Spans need access to the tracer `Tag`s.  The current tracer that a span references is the concrete implementation of the span: `stub`, `lightstep`, or `jaeger` and not our abstraction containing the `Tags`.

This PR updates it so that when spans are created they have a reference to our abstraction instead of the concrete tracer.

----
## Code trace of the issue
the tracer provides the ability to create spans (extract) from the wire in order to initialize spans.  These spans are then passed throughout an application so that they can be referenced by other spans.  The steps are:

- [tracer.extract](https://github.com/auth0/auth0-instrumentation/blob/master/lib/tracer.js#L157) is called on incoming request
- a span [is created by the concrete tracer ](https://github.com/auth0/auth0-instrumentation/blob/master/lib/tracer.js#L178)
- The span [abstraction passes a reference to the concrete tracer](https://github.com/auth0/auth0-instrumentation/blob/master/lib/tracer.js#L94)
- Other operations then access `span.tracer()` in order to [start a new span](https://github.com/auth0/auth0-instrumentation/blob/master/lib/tracer.js#L101) referencing the current span
- Most s[pans need to access some shared default tags](https://github.com/auth0/belgrano/pull/24/files#diff-72fb238fcec4c49f200cb91e94fc8450R82), but the tags are [only available on our tracer abstraction](https://github.com/auth0/auth0-instrumentation/blob/master/lib/tracer.js#L80) and not the concrete tracer implementation.
```
span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_CLIENT);
```