### PR TITLE
Added resources.memory.external metric for Node >=7.2

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -116,6 +116,11 @@ module.exports = function (pkg, env) {
       obj.gauge('resources.memory.heapTotal', memUsage.heapTotal, tags);
       obj.gauge('resources.memory.heapUsed', memUsage.heapUsed, tags);
 
+      // added in Node 7.2: memory usage of C++ objects bound to JavaScript objects managed by V8
+      if (memUsage.external) {
+        obj.gauge('resources.memory.external', memUsage.external, tags);
+      }
+
       pusage.stat(process.pid, function (err, stat) {
         if (err) {
           return;


### PR DESCRIPTION
Since Node 7.x we have an important metric to monitor native modules memory usage and find native objects memory leaks.

Reference: https://nodejs.org/api/process.html#process_process_memoryusage