### PR TITLE
Tracing: Express: Uses req.baseUrl for spanName

### DIFF
--- a/lib/tracer_middleware.js
+++ b/lib/tracer_middleware.js
@@ -3,10 +3,10 @@ const url = require('url');
 
 
 // createRequestSpan creates a new Span for an incoming request.
-function createRequestSpan(tracer, req) {
+function createRequestSpan(tracer, req, spanName) {
   const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
-  const name = req.path ? req.path : url.parse(req.url).pathname;
-  const span = tracer.startSpan(name, { childOf: wireCtx });
+  const nameFromReq = req.path ? req.path : url.parse(req.url).pathname;
+  const span = tracer.startSpan(spanName || nameFromReq, { childOf: wireCtx });
   span.setTag(tracer.Tags.HTTP_METHOD, req.method);
   span.setTag(tracer.Tags.SPAN_KIND, tracer.Tags.SPAN_KIND_RPC_SERVER);
   span.setTag(tracer.Tags.HTTP_URL, req.url.href ? req.url.href : req.url);
@@ -89,7 +89,7 @@ function hapiHelper(tracer) {
 module.exports = {
   express: function(tracer) {
     const mw = (req, res, next) => {
-      const span = createRequestSpan(tracer, req);
+      const span = createRequestSpan(tracer, req.baseUrl);
 
       // Include the trace context in response headers, to facilitate debugging.
       const responseHeaders = {};


### PR DESCRIPTION
Express tracing middleware was using `req.path` for the span name, which can include dynamic path components based on user ids, for an extremely high cardinality.

This uses express `req.baseUrl` which should be the generic express route NOT the actual matched request path.

https://expressjs.com/en/api.html#req.route



----
TODO 

https://expressjs.com/en/api.html#req.route