### PR TITLE
Add an alias of isEnabled (isTracerEnabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+<a name="v2.27.2"></a>
+# v2.27.1
+### Bugfix
+* Added `isTracingEnabled` parameter as an alias of `isEnabled` since `isEnabled`
+applies only to tracing but has a very generic name. `isEnabled` still works so we
+don't apply any breaking change but should be consider deprecated.
+
 <a name="v2.27.1"></a>
 # v2.27.1
 ### Bugfix

--- a/index.js
+++ b/index.js
@@ -5,6 +5,16 @@ var Metrics = require('./lib/metrics');
 var Profiler = require('./lib/profiler');
 var Tracer = require('./lib/tracer');
 
+/**
+ * @typedef {Object} InstrumentationParams
+ *
+ * @property {function} isTracerEnabled Determines whether tracer is enabled and allows
+ * to dynamically turn it on / off (e.g. using a flag)
+ * @property {function} isEnabled Deprecated: same as `isTracerEnabled`, use `isTracerEnabled`
+ * instead
+ * @property {string} fileRotationSignal Process signal to use to rotate the log file
+ */
+
 module.exports = {
   logger: stubs.logger,
   errorReporter: stubs.errorReporter,
@@ -13,6 +23,14 @@ module.exports = {
   tracer: stubs.tracer,
   initialized: false,
 
+  /**
+   * Initialize the instrumentation agent
+   *
+   * @param {Object} pkg Package configuration in general taken from package.jsons
+   * @param {Object} env Environment configuration for instrumentation
+   * @param {Object} serializers Logger serializers
+   * @param {InstrumentationParams} params Instrumentation parametrs
+   */
   init: function(pkg, env, serializers, params) {
     if (this.initialized) { return; }
 
@@ -21,7 +39,9 @@ module.exports = {
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
     this.tracer = Tracer(this, pkg, env, {
-      isEnabled: params && params.isEnabled,
+      // Using params.isEnabled should be consider legacy since it is a bit
+      // misleading because it only applies to tracing
+      isEnabled: params && (params.isTracerEnabled || params.isEnabled),
       logger: this.logger
     });
     this.initialized = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
isEnabled applied only to tracing, however, it was a bit misleading since when using in
initialization of the agent it might make you incorrectly believe it applies to the
whole agent.

`isEnabled` is left there (marked as deprecated) for backwards compatibility.