### PR TITLE
Resolve error on switcheable tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+<a name="v2.27.3"></a>
+# v2.27.3
+### Bugfix
+* Resolved error `spanContext.forEachBaggageItem is not a function` when switching
+from stubbed to basic tracer dynamically using the switchable tracer.
+
 <a name="v2.27.2"></a>
 # v2.27.1
 ### Bugfix

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -11,6 +11,7 @@ var emptySpan = {
   context: returnNull,
   tracer: () => { return emptyTracer; },
   setOperationName: noop,
+  isStub: true
 };
 
 var emptyTracer = {

--- a/lib/switchable_tracer.js
+++ b/lib/switchable_tracer.js
@@ -26,18 +26,34 @@ module.exports = function switchableTracer(options) {
     }
   }
 
+  function isSpanValidForTracer(isEnabled, span) {
+    const useStubs = !isEnabled;
+
+    return span && ((useStubs && span.isStub) || (!useStubs && !span.isStub));
+  }
+
   return {
     baseTracer,
     tracerStubs,
     startSpan: (name, options) => {
-      if (isProtectedEnabled()) {
+      const isEnabled = isProtectedEnabled();
+      const isParentValidForChild = !options || !options.childOf || isSpanValidForTracer(isEnabled, options.childOf);
+
+      if (!isParentValidForChild){
+        options = Object.assign({}, options);
+        delete options.childOf;
+      }
+
+      if (isEnabled) {
         return baseTracer.startSpan(name, options);
       }
 
       return tracerStubs.startSpan(name, options);
     },
     inject: (spanContext, format, carrier) => {
-      if (isProtectedEnabled()) {
+      const isEnabled = isProtectedEnabled();
+
+      if (isEnabled && isSpanValidForTracer(isEnabled, spanContext)) {
         return baseTracer.inject(spanContext, format, carrier);
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/switchable_tracer.test.js
+++ b/test/switchable_tracer.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const buildSwitchableTracer = require('../lib/switchable_tracer');
+const stubs = require('../lib/stubs');
 
 describe('Switchable tracer', () => {
   function buildMockTracer(tags) {
@@ -121,6 +122,30 @@ describe('Switchable tracer', () => {
       assert.equal(tracerStubsMock.getResult().extractCalls[0].carrier, carrier);
       assert.equal(baseTracerMock.getResult().extractCalls.length, 0);
     });
+
+    describe('and when creating a span with a non stubbed parent', () => {
+      it('removes the parent', () => {
+        const name = 'name';
+        const options = { childOf: {} };
+        switchableTracer.startSpan(name, options);
+
+        assert.equal(tracerStubsMock.getResult().startSpanCalls[0].name, name);
+        assert.deepEqual(tracerStubsMock.getResult().startSpanCalls[0].options, {});
+        assert.equal(baseTracerMock.getResult().startSpanCalls.length, 0);
+      });
+    });
+
+    describe('and when creating a span with a stubbed parent', () => {
+      it('does not removes the parent', () => {
+        const name = 'name';
+        const options = { childOf: stubs.tracer.startSpan() };
+        switchableTracer.startSpan(name, options);
+
+        assert.equal(tracerStubsMock.getResult().startSpanCalls[0].name, name);
+        assert.equal(tracerStubsMock.getResult().startSpanCalls[0].options, options);
+        assert.equal(baseTracerMock.getResult().startSpanCalls.length, 0);
+      });
+    });
   });
 
   describe('when tracer is enabled', () => {
@@ -157,6 +182,20 @@ describe('Switchable tracer', () => {
       assert.equal(tracerStubsMock.getResult().injectCalls.length, 0);
     });
 
+    describe('and when injecting a stubbed span when the tracer is enabled', () => {
+      it('does not call the tracer (calls the stub instead)', () => {
+        const format = 'format';
+        const carrier = 'carrier';
+        const spanContext = stubs.tracer.startSpan();
+        switchableTracer.inject(spanContext, format, carrier);
+
+        assert.equal(tracerStubsMock.getResult().injectCalls[0].format, format);
+        assert.equal(tracerStubsMock.getResult().injectCalls[0].carrier, carrier);
+        assert.equal(tracerStubsMock.getResult().injectCalls[0].spanContext, spanContext);
+        assert.equal(baseTracerMock.getResult().injectCalls.length, 0);
+      });
+    });
+
     it('calls extract from base tracer', () => {
       const format = 'format';
       const carrier = 'carrier';
@@ -165,6 +204,30 @@ describe('Switchable tracer', () => {
       assert.equal(baseTracerMock.getResult().extractCalls[0].format, format);
       assert.equal(baseTracerMock.getResult().extractCalls[0].carrier, carrier);
       assert.equal(tracerStubsMock.getResult().extractCalls.length, 0);
+    });
+
+    describe('and when creating an span with an stubbed parent', () => {
+      it('removes the parent', () => {
+        const name = 'name';
+        const options = { childOf: stubs.tracer.startSpan() };
+        switchableTracer.startSpan(name, options);
+
+        assert.equal(baseTracerMock.getResult().startSpanCalls[0].name, name);
+        assert.deepEqual(baseTracerMock.getResult().startSpanCalls[0].options, {});
+        assert.equal(tracerStubsMock.getResult().startSpanCalls.length, 0);
+      });
+    });
+
+    describe('and when creating an span with an non stubbed parent', () => {
+      it('does not removes the parent', () => {
+        const name = 'name';
+        const options = { childOf: { myChildSpan: 1 } };
+        switchableTracer.startSpan(name, options);
+
+        assert.equal(baseTracerMock.getResult().startSpanCalls[0].name, name);
+        assert.equal(baseTracerMock.getResult().startSpanCalls[0].options, options);
+        assert.equal(tracerStubsMock.getResult().startSpanCalls.length, 0);
+      });
     });
   });
 });


### PR DESCRIPTION
Resolved error `spanContext.forEachBaggageItem is not a function` when switching
from stubbed to basic tracer dynamically using the switchable tracer.

This error happens when feeding the lightstep tracer with a stubbed span.