### PR TITLE
Add sentry release

### DIFF
--- a/lib/error_reporter.js
+++ b/lib/error_reporter.js
@@ -6,7 +6,9 @@ module.exports = function(pkg, env) {
   }
 
   var raven = require('raven');
-  var client = new raven.Client(env.ERROR_REPORTER_URL);
+  var client = new raven.Client(env.ERROR_REPORTER_URL, {
+    release: env.SENTRY_RELEASE || `${pkg.name}@${pkg.version}`
+  });
 
   client.hapi = {
     plugin: hapiPluginBuilder(client)


### PR DESCRIPTION
With the release team we will start reporting releases and deployments to sentry,
telling sentry the artiifact version the code belongs to will provide us advantages
as for example detecting in which release an error was introduced, providing insight
on the releases, etc.

NOTE: Keep in mind that releases are global in sentry that's why we need to prefix the
version with the pkg.name.