### PR TITLE
Fix metrics when using METRICS_API_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+<a name="v2.29.1"></a>
+# v2.29.1
+
+### Bugfix
+- Fix metrics when using METRICS_API_KEY
+
 <a name="v2.29.0"></a>
 # v2.29.0
 

--- a/lib/datadog_client_to_statsd_adapter.js
+++ b/lib/datadog_client_to_statsd_adapter.js
@@ -1,0 +1,44 @@
+/**
+ * Wraps datadog agent to make api compatible with node-statsd
+ * API. In particular node-statsd accepts a callback as it last parameter
+ * whereas the datadog agent accepts a timestamp as a last paramter but does
+ * not accept a callback. The API (without the callback) used to be compatible,
+ * however this feature was broken for some time after datadog agent update
+ * since it is not very used.
+ *
+ * More information:
+ * https://github.com/dbader/node-datadog-metrics/blob/ca55a11/lib/loggers.js#L71
+ * VS
+ * https://github.com/sivy/node-statsd/blob/6bce04f/lib/statsd.js#L75 (sampleRate is not mandatory)
+ */
+class DatadogClientToStatsdAdapter {
+  constructor(wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  gauge(name, value, tags, callback) {
+    this.wrapped.gauge(name, value, tags);
+
+    if (callback) { setImmediate(callback); }
+  }
+
+  increment(name, value, tags, callback) {
+    this.wrapped.increment(name, value, tags);
+
+    if (callback) { setImmediate(callback); }
+  }
+
+  histogram(name, value, tags, callback) {
+    this.wrapped.histogram(name, value, tags);
+
+    if (callback) { setImmediate(callback); }
+  }
+
+  flush() {
+    if (typeof this.wrapped.flush === 'function') {
+      this.wrapped.flush();
+    }
+  }
+}
+
+module.exports = DatadogClientToStatsdAdapter;

--- a/lib/metrics_factory.js
+++ b/lib/metrics_factory.js
@@ -1,6 +1,7 @@
 const url = require('url');
 const StatsD = require('node-statsd');
 const datadog = require('datadog-metrics');
+const DatadogClientToStatsdAdapter = require('./datadog_client_to_statsd_adapter');
 
 function buildStatsD(pkg, env) {
   const parsedURL = url.parse(env.STATSD_HOST);
@@ -13,12 +14,14 @@ function buildStatsD(pkg, env) {
 }
 
 function buildDataDog(pkg, env) {
-  return new datadog.BufferedMetricsLogger({
+  const dd = new datadog.BufferedMetricsLogger({
     apiKey: env.METRICS_API_KEY,
     host: env.METRICS_HOST || require('os').hostname(),
     prefix: env.METRICS_PREFIX || (pkg.name + '.'),
     flushIntervalSeconds: env.METRICS_FLUSH_INTERVAL || 15
   });
+
+  return new DatadogClientToStatsdAdapter(dd);
 }
 
 exports.create = (pkg, env) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -219,6 +219,89 @@ describe('metrics', function() {
         $metrics.flush();
         sinon.assert.called(metricsSpy);
       });
+
+      describe('API adapter', () => {
+        function buildMetricsMock() {
+          const gauge = sinon.stub();
+          const increment = sinon.stub();
+          const histogram = sinon.stub();
+          const flush = sinon.stub();
+
+          const metrics = $require('../lib/metrics_factory', {
+            'datadog-metrics': {
+              BufferedMetricsLogger: function() {
+                return { gauge, increment, histogram, flush };
+              }
+            }
+          }).create({ name: 'test' }, {
+            METRICS_API_KEY: 'datadogkey'
+          });
+
+          return { metrics, gauge, increment, histogram, flush };
+        }
+
+        describe('without callback', () => {
+          it('calls gauge correctly', () => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.gauge('my_metric', 1, { mytag: 'value' });
+
+            sinon.assert.calledOnce(mock.gauge);
+            sinon.assert.calledWith(mock.gauge, 'my_metric', 1, { mytag: "value" });
+          });
+
+          it('calls increment correctly', () => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.increment('my_metric', 1, { mytag: 'value' });
+
+            sinon.assert.calledOnce(mock.increment);
+            sinon.assert.calledWith(mock.increment, 'my_metric', 1, { mytag: "value" });
+          });
+
+          it('calls histogram correctly', () => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.histogram('my_metric', 100, { mytag: 'value' });
+
+            sinon.assert.calledOnce(mock.histogram);
+            sinon.assert.calledWith(mock.histogram, 'my_metric', 100, { mytag: "value" });
+          });
+        });
+
+        describe('with callback', () => {
+          it('calls gauge correctly', (done) => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.gauge('my_metric', 1, { mytag: 'value' }, () => {
+              sinon.assert.calledOnce(mock.gauge);
+              sinon.assert.calledWith(mock.gauge, 'my_metric', 1, { mytag: "value" });
+              done();
+            });
+          });
+
+          it('calls increment correctly', (done) => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.increment('my_metric', 1, { mytag: 'value' }, () => {
+              sinon.assert.calledOnce(mock.increment);
+              sinon.assert.calledWith(mock.increment, 'my_metric', 1, { mytag: "value" });
+              done();
+            });
+          });
+
+          it('calls histogram correctly', (done) => {
+            const mock = buildMetricsMock();
+
+            mock.metrics.histogram('my_metric', 100, { mytag: 'value' }, () => {
+              sinon.assert.calledOnce(mock.histogram);
+              sinon.assert.calledWith(mock.histogram, 'my_metric', 100, { mytag: "value" });
+              done();
+            });
+          });
+        });
+
+      });
     });
   });
 });


### PR DESCRIPTION
METRICS_API_KEY mode was broken because it was passing the callback
as a parameter when in fact the datadog agent does not accept a callback
and the callback was being put in place of the timestamp associated
with the metrics.
