### PR TITLE
Support sending the whole environment + release channel to sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+<a name="v2.30.0"></a>
+# v2.30.0
+
+### Feature
+- Support option `splitEnvironmentByReleaseChannel` to send env.ENVIRONMENT:env.RELEASE_CHANNEL
+to Sentry. Sentry still allows you to select more than one environment in case we want
+to get back to the original setup of having all the environment together regardless of the
+release channel.
+
+### Bugfix
+- Fix metrics when using METRICS_API_KEY
+
 <a name="v2.29.1"></a>
 # v2.29.1
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,12 @@ var env = require('./lib/env');
 var agent = require('auth0-instrumentation');
 var request = require('request');
 
-agent.init(pkg, env);
+agent.init(pkg, env, {
+  errorReporter: {
+    splitEnvironmentByReleaseChannel: true
+  }
+});
+
 var tracer = agent.tracer;
 var wrapRequest = tracer.agent.helpers.wrapRequest;
 
@@ -347,7 +352,10 @@ const env = {
   'TRACE_AGENT_USE_TLS': true,
   'TRACE_AGENT_HOST': 'localhost',
   'TRACE_AGENT_PORT': 443,
-  'TRACE_REPORTING_INTERVAL_MILLIS': 500
+  'TRACE_REPORTING_INTERVAL_MILLIS': 500,
+
+  'SENTRY_RELEASE': '...', // Optional overrides the default sentry release name (package.name@package.version)
+  'SENTRY_ENVIRONMENT': '...' // Optional override for the environment we send to sentry (default: environment or environment:release channel depending on splitEnvironmentByReleaseChannel)
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -30,12 +30,17 @@ module.exports = {
    * @param {Object} env Environment configuration for instrumentation
    * @param {Object} serializers Logger serializers
    * @param {InstrumentationParams} params Instrumentation parametrs
+   * @param {Object} [params.errorReporter]
+   * @param {boolean} params.errorReporter.splitEnvironmentByReleaseChannel Whether to send
+   * environmentName + releaseChannel to sentry instead of just environmentName
    */
   init: function(pkg, env, serializers, params) {
     if (this.initialized) { return; }
 
     this.logger = Logger(pkg, env, serializers);
-    this.errorReporter = ErrorReporter(pkg, env);
+    this.errorReporter = ErrorReporter(pkg, env, {
+      splitEnvironmentByReleaseChannel: params && params.errorReporter && params.errorReporter.splitEnvironmentByReleaseChannel
+    });
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
     this.tracer = Tracer(this, pkg, env, {

--- a/lib/error_reporter.js
+++ b/lib/error_reporter.js
@@ -1,13 +1,34 @@
 const hapiPluginBuilder = require('./hapi_plugin_builder');
 
-module.exports = function(pkg, env) {
+/**
+ * @param {Object} options
+ * @param {boolean} options.useFullyQualifiedEnvironment Send release channel as part of the environment
+ */
+module.exports = function(pkg, env, options) {
+  options = options || {};
+
   if (!env.ERROR_REPORTER_URL) {
     return require('./stubs').errorReporter;
   }
 
-  var raven = require('raven');
+  // `splitEnvironmentByReleaseChannel` is preferred over overriding the environment
+  // manually: for this to be useful it must match the convention we are
+  // using when sending the deployments to sentry.
+  //
+  // The reason to support this format instead of plain-old environment is so
+  // we can take advantage of sentry features, for example, we might decide to
+  // take some action if we see an increase of error in canary but not in stable.
+  // Those capabilities are associated with sentry being able to correctly isolate
+  // the different deployment environments.
+  var environment = env.ENVIRONMENT;
+  if (env.RELEASE_CHANNEL && options.splitEnvironmentByReleaseChannel) {
+    environment = `${env.ENVIRONMENT}:${env.RELEASE_CHANNEL}`;
+  }
+
+  var raven = options.reporterLib || require('raven');
   var client = new raven.Client(env.ERROR_REPORTER_URL, {
-    release: env.SENTRY_RELEASE || `${pkg.name}@${pkg.version}`
+    release: env.SENTRY_RELEASE || `${pkg.name}@${pkg.version}`,
+    environment: env.SENTRY_ENVIRONMENT || environment
   });
 
   client.hapi = {

--- a/lib/error_reporter.js
+++ b/lib/error_reporter.js
@@ -1,4 +1,5 @@
 const hapiPluginBuilder = require('./hapi_plugin_builder');
+const defaultReporterLib = require('raven');
 
 /**
  * @param {Object} options
@@ -25,7 +26,7 @@ module.exports = function(pkg, env, options) {
     environment = `${env.ENVIRONMENT}:${env.RELEASE_CHANNEL}`;
   }
 
-  var raven = options.reporterLib || require('raven');
+  var raven = options.reporterLib || defaultReporterLib;
   var client = new raven.Client(env.ERROR_REPORTER_URL, {
     release: env.SENTRY_RELEASE || `${pkg.name}@${pkg.version}`,
     environment: env.SENTRY_ENVIRONMENT || environment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.29.1",
+  "version": "2.30.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/error_reporter.test.js
+++ b/test/error_reporter.test.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const buildErrorReporter = require('../lib/error_reporter');
+
+describe('error reporter', () => {
+  function buildErrorReporterClient(ClientConstructorStub) {
+    return {
+      Client: ClientConstructorStub,
+      middleware: {
+        express: {
+          requestHandler: () => {},
+          errorHandler: () => {}
+        }
+      }
+    };
+  }
+
+  describe('when using `splitEnvironmentByReleaseChannel` option', () => {
+    it('sends environment as environment : release channel to sentry', () => {
+      let ravenURL;
+      let ravenOptions;
+
+      const ClientConstructorStub = function(url, options) {
+        ravenURL = url;
+        ravenOptions = options;
+      };
+
+      buildErrorReporter({
+        name: 'myName',
+        version: '0.0.0'
+      }, {
+        ERROR_REPORTER_URL: 'myErrorReporter',
+        ENVIRONMENT: 'myEnvironment',
+        RELEASE_CHANNEL: 'myReleaseChannel'
+      }, {
+        splitEnvironmentByReleaseChannel: true,
+        reporterLib: buildErrorReporterClient(ClientConstructorStub)
+      });
+
+      assert.equal(ravenURL, 'myErrorReporter');
+      assert.deepEqual(ravenOptions,  {
+        release: `myName@0.0.0`,
+        environment: `myEnvironment:myReleaseChannel`
+      });
+    });
+  });
+
+  it('sends the environment to sentry', () => {
+    let ravenURL;
+    let ravenOptions;
+
+    const ClientConstructorStub = function(url, options) {
+      ravenURL = url;
+      ravenOptions = options;
+    };
+
+    buildErrorReporter({
+      name: 'myName',
+      version: '0.0.0'
+    }, {
+      ERROR_REPORTER_URL: 'myErrorReporter',
+      ENVIRONMENT: 'myEnvironment',
+      RELEASE_CHANNEL: 'myReleaseChannel'
+    }, {
+      reporterLib: buildErrorReporterClient(ClientConstructorStub)
+    });
+
+    assert.equal(ravenURL, 'myErrorReporter');
+    assert.deepEqual(ravenOptions,  {
+      release: `myName@0.0.0`,
+      environment: `myEnvironment`
+    });
+  });
+});


### PR DESCRIPTION
Support sending `useFullyQualifiedEnvironment` to send env.ENVIRONMENT:env.RELEASE_CHANNEL
to Sentry. Sentry still allows you to select more than one environment in case we want
to get back to the original setup of having all the environment together regardless of the
release channel.