### PR TITLE
Improve error reporter to include release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Error reporter for logger and plain old error reporter exposed on index were being
 instantiated twice each time with different arguments, this PR fix that by instantiating the error
 reporter a single time on index and injecting it into the logger.
+- The version of the raven client being used didn't support release as an option, raven version
+was updated to raven@0.12.0 which keeps same API as before. Update to new sentry version
+has been tracked.
 
 <a name="v2.30.0"></a>
 # v2.30.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+<a name="v2.30.1"></a>
+# v2.30.1
+
+### Bugfix
+- Error reporter for logger and plain old error reporter exposed on index were being
+instantiated twice each time with different arguments, this PR fix that by instantiating the error
+reporter a single time on index and injecting it into the logger.
+
 <a name="v2.30.0"></a>
 # v2.30.0
 

--- a/index.js
+++ b/index.js
@@ -37,10 +37,12 @@ module.exports = {
   init: function(pkg, env, serializers, params) {
     if (this.initialized) { return; }
 
-    this.logger = Logger(pkg, env, serializers);
-    this.errorReporter = ErrorReporter(pkg, env, {
+    const errorReporter = ErrorReporter(pkg, env, {
       splitEnvironmentByReleaseChannel: params && params.errorReporter && params.errorReporter.splitEnvironmentByReleaseChannel
     });
+
+    this.errorReporter = errorReporter;
+    this.logger = Logger(pkg, env, serializers, null, errorReporter);
     this.metrics = Metrics(pkg, env);
     this.profiler = new Profiler(this, pkg, env);
     this.tracer = Tracer(this, pkg, env, {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,12 +6,11 @@ const HttpWritableStream = require('auth0-common-logging').Streams.HttpWritableS
 const KinesisWritable = require('aws-kinesis-writable');
 
 const utils = require('./utils');
-const ErrorReporter = require('./error_reporter');
 const KeepAliveAgentRegistry = require('./keep_alive_agent');
 const decorateLogger = require('./utils').decorateLogger;
 const spawn = require('child_process').spawn;
 
-module.exports = function getLogger(pkg, env, serializers, agent) {
+module.exports = function getLogger(pkg, env, serializers, agent, errorReporter) {
   if (!serializers) {
     serializers = Serializers;
   }
@@ -87,7 +86,7 @@ module.exports = function getLogger(pkg, env, serializers, agent) {
 
   bunyan_streams.push({
     name: 'sentry',
-    stream: new Auth0SentryStream(ErrorReporter(pkg, env)),
+    stream: new Auth0SentryStream(errorReporter),
     level: env.ERROR_REPORTER_LOG_LEVEL || 'error',
     type: 'raw'
   });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "opentracing": "^0.14.3",
     "pidusage": "^1.0.4",
     "protobufjs": "^6.8.8",
-    "raven": "^0.10.0",
+    "raven": "0.12.0",
     "uuid": "^3.0.1",
     "v8-profiler-node8": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.30.1",
+  "version": "2.30.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "opentracing": "^0.14.3",
     "pidusage": "^1.0.4",
     "protobufjs": "^6.8.8",
-    "raven": "0.12.0",
+    "raven": "0.12.1",
     "uuid": "^3.0.1",
     "v8-profiler-node8": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-instrumentation",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -2,21 +2,26 @@
 
 const assert = require('assert');
 const sentry = require('../lib/error_reporter')({}, {});
-const logger = require('../lib/logger')({ name: 'test' },
-                                        { LOG_LEVEL: 'fatal',
-                                          PURPOSE: 'test-purpose',
-                                          ENVIRONMENT: 'test-env',
-                                          RELEASE_CHANNEL: 'test-channel',
-                                          AWS_REGION: 'test-region'
-                                        });
+const buildLogger = require('../lib/logger');
 const spy = require('sinon').spy;
 
 describe('logger', function() {
+  let logger;
+
   beforeEach(function() {
     sentry.captureException = spy();
     sentry.captureMessage = spy();
     sentry.captureException.resetHistory();
     sentry.captureMessage.resetHistory();
+
+    logger = buildLogger({ name: 'test' },
+                                        { LOG_LEVEL: 'fatal',
+                                          PURPOSE: 'test-purpose',
+                                          ENVIRONMENT: 'test-env',
+                                          RELEASE_CHANNEL: 'test-channel',
+                                          AWS_REGION: 'test-region'
+                                        }, null, null, sentry);
+
   });
 
   describe('logger.child()', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,6 @@ ajv@^5.3.0:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ammo@3.x.x:
   version "3.0.0"
@@ -165,12 +164,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
 async@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.0.tgz#2796642723573859565633fc6274444bee2f8ce3"
-  integrity sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -186,7 +183,6 @@ auth0-common-logging@auth0/auth0-common-logging#v2.22.0:
 aws-kinesis-writable@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/aws-kinesis-writable/-/aws-kinesis-writable-4.2.3.tgz#b3ac445c50352315db5f204efc627f54aad629ef"
-  integrity sha512-MLE9u7fgu4iaQoX4J68r/OHnf5LyzhuEgjt5YcN4HhdA2jjgJXLXtM/GZTtMI7/Llq48V8CJZpR4nbQThJATvQ==
   dependencies:
     aws-sdk "^2.178.0"
     fast-safe-stringify "^2.0.6"
@@ -196,7 +192,6 @@ aws-kinesis-writable@^4.2.3:
 aws-sdk@^2.178.0:
   version "2.481.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.481.0.tgz#61f46b830100947cd9156d721369975125c19f36"
-  integrity sha512-uwFGzwb2bKkh2KdX0nsebGqQNItZZ6j8+oL03jqSxCouO4FvFZpo8jd0ZnmkEeL6mWvv52WqV8HHhQNEyWkfNQ==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -231,7 +226,6 @@ balanced-match@^1.0.0:
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
-  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -246,7 +240,6 @@ big-time@2.x.x:
 bignumber.js@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-1.1.1.tgz#1a415d9ac014c13256af1feed9d1a3e5717a8cf7"
-  integrity sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc=
 
 blocked@^1.2.1:
   version "1.2.1"
@@ -312,7 +305,6 @@ browser-stdout@1.3.0:
 buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -409,7 +401,6 @@ chalk@^1.1.1:
 chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
-  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
 cli-table@^0.3.1:
   version "0.3.1"
@@ -538,7 +529,6 @@ dashdash@^1.12.0:
 datadog-metrics@~0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/datadog-metrics/-/datadog-metrics-0.8.1.tgz#be87237109a7084193c668d80112533ef00e3f21"
-  integrity sha512-qTSKnddO6GxTJW9FYpmWjvvift3qfyMurDjwNjJnJhBk76pBdDhC0B5V9V+XwPdn4r42qu48kwXNuHJslXlDOA==
   dependencies:
     debug "3.1.0"
     dogapi "1.1.0"
@@ -568,7 +558,6 @@ decamelize@^1.1.1:
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -609,7 +598,6 @@ diff@^3.5.0:
 dogapi@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/dogapi/-/dogapi-1.1.0.tgz#71a43865ad4bb4cb18bc3e13cf769971f501030a"
-  integrity sha1-caQ4Za1LtMsYvD4Tz3aZcfUBAwo=
   dependencies:
     extend "^3.0.0"
     json-bigint "^0.1.4"
@@ -668,12 +656,10 @@ etag@~1.8.1:
 eventemitter3@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"
-  integrity sha1-R3hr2qCHyvext15zq8XH1UAVjNA=
 
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 execa@^0.7.0:
   version "0.7.0"
@@ -745,7 +731,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-safe-stringify@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
-  integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
 
 fill-keys@^1.0.2:
   version "1.0.2"
@@ -799,7 +784,6 @@ fresh@0.5.2:
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
-  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
 
@@ -823,7 +807,6 @@ gauge@~2.7.3:
 gc-stats@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/gc-stats/-/gc-stats-1.2.1.tgz#f3e1bf7e28a385780db22a81681b064932e358da"
-  integrity sha512-CPQfMBQPGkqG4upxCn4zHxYZo20woPClSeqnC/WK8pFqlfAtz6zpxbOfnmxOIDYiC26H/pYlWQfdoPVGoqxFUA==
   dependencies:
     nan "^2.10.0"
     node-pre-gyp "^0.11.0"
@@ -877,7 +860,6 @@ glob@^7.0.5:
 google-protobuf@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
-  integrity sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA==
 
 graceful-fs@^4.1.2:
   version "4.1.11"
@@ -988,7 +970,6 @@ heavy@^4.0.4:
 hex2dec@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hex2dec/-/hex2dec-1.0.1.tgz#949bb33f1fdbbeab20e06403a00fc7d5ff284207"
-  integrity sha1-lJuzPx/bvqsg4GQDoA/H1f8oQgc=
 
 hoek@2.x.x:
   version "2.16.3"
@@ -1047,24 +1028,20 @@ iconv-lite@0.4.19:
 iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
 ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
-  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
   dependencies:
     minimatch "^3.0.4"
 
@@ -1186,7 +1163,6 @@ jaeger-client@3.12.0:
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 joi@10.x.x:
   version "10.6.0"
@@ -1229,7 +1205,6 @@ jsbn@~0.1.0:
 json-bigint@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.1.4.tgz#b5d40b8a9009e92f157f7c079db097001830e01e"
-  integrity sha1-tdQLipAJ6S8Vf3wHnbCXABgw4B4=
   dependencies:
     bignumber.js "~1.1.1"
 
@@ -1241,7 +1216,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -1271,7 +1246,6 @@ lcid@^1.0.0:
 lightstep-tracer@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/lightstep-tracer/-/lightstep-tracer-0.21.0.tgz#7c04b6d2da44d67a2b0e04fe0883e76d56a5386b"
-  integrity sha512-c5gAi937ac7hR5HIZiqAh+iXTfVLJblUYzJOvJZi8wSub1F656EcNbQn/shpAgSYArnl/tEw8IbrLb/eJd1Yzw==
   dependencies:
     async "1.5.0"
     eventemitter3 "1.1.1"
@@ -1350,7 +1324,6 @@ lodash.keys@^3.0.0:
 lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.omit@^4.5.0:
   version "4.5.0"
@@ -1363,7 +1336,6 @@ lodash.throttle@^4.1.1:
 lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lolex@^2.3.2, lolex@^2.7.1:
   version "2.7.1"
@@ -1384,9 +1356,9 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lsmod@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-0.0.3.tgz#17e13d4e1ae91750ea5653548cd89e7147ad0244"
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://a0us.jfrog.io/a0us/api/npm/npm/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1479,7 +1451,6 @@ minimist@^1.1.1, minimist@^1.2.0:
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
-  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
@@ -1487,7 +1458,6 @@ minipass@^2.2.1, minipass@^2.3.4:
 minizlib@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
-  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -1541,7 +1511,6 @@ mv@~2:
 nan@^2.10.0, nan@^2.5.1:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.0.tgz#9d443fdb5e13a20770cc5e602eee59760a685885"
-  integrity sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==
 
 nan@^2.3.3:
   version "2.10.0"
@@ -1554,7 +1523,6 @@ ncp@~2.0.0:
 needle@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
-  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -1595,7 +1563,6 @@ node-int64@^0.4.0:
 node-pre-gyp@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
-  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -1639,12 +1606,10 @@ normalize-package-data@^2.3.2:
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
-  integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
 
 npm-packlist@^1.1.6:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
-  integrity sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -1892,7 +1857,6 @@ psl@^1.1.24:
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@2.x.x:
   version "2.1.0"
@@ -1905,7 +1869,6 @@ punycode@^1.4.1:
 q@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qs@6.5.1:
   version "6.5.1"
@@ -1918,18 +1881,18 @@ qs@^6.5.1, qs@~6.5.2:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-0.10.0.tgz#2144346322955bd9e1519ac66081c63b178b452f"
+raven@0.12.0:
+  version "0.12.0"
+  resolved "https://a0us.jfrog.io/a0us/api/npm/npm/raven/-/raven-0.12.0.tgz#53370f749a55c9a092ce704e3801345a913de5a3"
   dependencies:
     cookie "0.1.0"
-    lsmod "~0.0.3"
+    json-stringify-safe "^5.0.1"
+    lsmod "1.0.0"
     node-uuid "~1.4.1"
     stack-trace "0.0.7"
 
@@ -1945,7 +1908,6 @@ raw-body@2.3.2:
 rc@^1.0.0, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   dependencies:
     deep-extend "^0.6.0"
     ini "~1.3.0"
@@ -2030,7 +1992,6 @@ resolve@~1.5.0:
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rimraf@^2.6.1:
   version "2.6.2"
@@ -2059,7 +2020,6 @@ safe-json-stringify@~1:
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 samsam@1.3.0:
   version "1.3.0"
@@ -2068,7 +2028,6 @@ samsam@1.3.0:
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
 sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
@@ -2165,14 +2124,12 @@ sinon@^6.1.4:
 source-map-support@0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.3.tgz#34900977d5ba3f07c7757ee72e73bb1a9b53754f"
-  integrity sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=
   dependencies:
     source-map "0.1.32"
 
 source-map@0.1.32:
   version "0.1.32"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
-  integrity sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=
   dependencies:
     amdefine ">=0.0.4"
 
@@ -2365,7 +2322,6 @@ supports-color@^5.4.0:
 tar@^4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
@@ -2386,7 +2342,6 @@ text-encoding@^0.6.4:
 thrift@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.11.0.tgz#256115e4ff87871e12537f4b510bd2b425e13990"
-  integrity sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=
   dependencies:
     node-int64 "^0.4.0"
     q "^1.5.0"
@@ -2453,7 +2408,6 @@ unpipe@1.0.0, unpipe@~1.0.0:
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -2477,7 +2431,6 @@ uuid@^3.0.1:
 v8-profiler-node8@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz#2558f5dab7622f2305213e6ccb4dde1f66cc631f"
-  integrity sha512-DD7L0c/2KeFFQxs20VaFPHq/CSintttW4YB+QJdJ5ZohxOegbsMCvnZKHRHVA9UZfVYqq6ZsLaywe74+3JpZjw==
   dependencies:
     nan "^2.5.1"
     node-pre-gyp "^0.11.0"
@@ -2564,14 +2517,12 @@ wreck@^6.3.0:
 "ws@>= 2.2.3":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
-  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
   dependencies:
     async-limiter "~1.0.0"
 
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
@@ -2579,7 +2530,6 @@ xml2js@0.4.19:
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xorshift@^0.2.0:
   version "0.2.1"
@@ -2600,7 +2550,6 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^7.0.0:
   version "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,7 +1358,7 @@ lru-cache@^4.0.1:
 
 lsmod@1.0.0:
   version "1.0.0"
-  resolved "https://a0us.jfrog.io/a0us/api/npm/npm/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
+  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1886,9 +1886,9 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven@0.12.0:
-  version "0.12.0"
-  resolved "https://a0us.jfrog.io/a0us/api/npm/npm/raven/-/raven-0.12.0.tgz#53370f749a55c9a092ce704e3801345a913de5a3"
+raven@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-0.12.1.tgz#dad6b485e85bfac8f9af5fbb4c7a0d7c8350fbc7"
   dependencies:
     cookie "0.1.0"
     json-stringify-safe "^5.0.1"


### PR DESCRIPTION
- We were instantiating the error reporter twice, each time with different
options, this PR fix error reporter instantiation by injecting it into the logger.
- The version of the raven client being used didn't support release as an option