### PR TITLE
Metrics: Support Omitting Metric Prefix

### DIFF
--- a/lib/metrics_factory.js
+++ b/lib/metrics_factory.js
@@ -2,13 +2,14 @@ const url = require('url');
 const StatsD = require('node-statsd');
 const datadog = require('datadog-metrics');
 const DatadogClientToStatsdAdapter = require('./datadog_client_to_statsd_adapter');
+const utils = require('./utils');
 
 function buildStatsD(pkg, env) {
   const parsedURL = url.parse(env.STATSD_HOST);
   return new StatsD({
     host: parsedURL.hostname,
     port: Number(parsedURL.port),
-    prefix: env.METRICS_PREFIX || (pkg.name + '.'),
+    prefix: utils.buildMetricPrefix(env, pkg),
     cacheDns: true
   });
 }
@@ -17,7 +18,7 @@ function buildDataDog(pkg, env) {
   const dd = new datadog.BufferedMetricsLogger({
     apiKey: env.METRICS_API_KEY,
     host: env.METRICS_HOST || require('os').hostname(),
-    prefix: env.METRICS_PREFIX || (pkg.name + '.'),
+    prefix: utils.buildMetricPrefix(env, pkg),
     flushIntervalSeconds: env.METRICS_FLUSH_INTERVAL || 15
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,22 +21,18 @@ exports.processTags = function(tags) {
 /**
  * buildMetricPrefix constructs a prefix that will be used for all
  * submitted metrics.  It supports omitting the prefix completely
- * when METRICS_OMIT_PREFIX is passed in.  This is explicit
- * in order to maintain backwards compatibility with current clients
- * whom expect that not including a prefix will result in using the
- * package.json name as the prefix.  This is important because
- * many clients have monitors and dashboards referencing these metrics.
+ * when METRICS_PREFIX is set to an empty string.
  *
  * @param env
  * @param pkg
  * @returns {string|string}
  */
 exports.buildMetricPrefix = function(env, pkg) {
-  if (env.METRICS_OMIT_PREFIX) {
-    return '';
+  if (typeof env.METRICS_PREFIX !== "undefined") {
+    return env.METRICS_PREFIX;
   }
 
-  return env.METRICS_PREFIX || (pkg.name + '.');
+  return pkg.name + '.';
 };
 
 exports.buildKinesisOptions = function (configMap, keepAliveAgent) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,28 @@ exports.processTags = function(tags) {
   return [];
 };
 
+
+/**
+ * buildMetricPrefix constructs a prefix that will be used for all
+ * submitted metrics.  It supports omitting the prefix completely
+ * when METRICS_OMIT_PREFIX is passed in.  This is explicit
+ * in order to maintain backwards compatibility with current clients
+ * whom expect that not including a prefix will result in using the
+ * package.json name as the prefix.  This is important because
+ * many clients have monitors and dashboards referencing these metrics.
+ *
+ * @param env
+ * @param pkg
+ * @returns {string|string}
+ */
+exports.buildMetricPrefix = function(env, pkg) {
+  if (env.METRICS_OMIT_PREFIX) {
+    return '';
+  }
+
+  return env.METRICS_PREFIX || (pkg.name + '.');
+};
+
 exports.buildKinesisOptions = function (configMap, keepAliveAgent) {
   return {
     accessKeyId: configMap.AWS_ACCESS_KEY_ID,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -48,4 +48,21 @@ describe('Utils', function() {
       });
     });
   });
+  describe('buildMetricPrefix', function() {
+    it('should return empty string if omit prefix is specified', function() {
+      assert('' === utils.buildMetricPrefix({
+        METRICS_OMIT_PREFIX: 1,
+      }));
+    });
+    it('should return METRICS_PREFIX value if specified', function() {
+      assert('hello.' === utils.buildMetricPrefix({
+        METRICS_PREFIX: 'hello.',
+      }));
+    });
+    it('should default to pkg.name', function() {
+      assert('test.' === utils.buildMetricPrefix({}, {
+        name: 'test',
+      }));
+    });
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -51,7 +51,7 @@ describe('Utils', function() {
   describe('buildMetricPrefix', function() {
     it('should return empty string if omit prefix is specified', function() {
       assert('' === utils.buildMetricPrefix({
-        METRICS_OMIT_PREFIX: 1,
+        METRICS_PREFIX: '',
       }));
     });
     it('should return METRICS_PREFIX value if specified', function() {


### PR DESCRIPTION
refs #SRE-1537

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR enables omitting the metric prefix from metrics. Prior to this change metrics would always be submitted with a prefix, either a prefix passed in through tne environment, or the package.json name, which results in metrics that look like:

```
agent.init(pkg, {
  STATSD_HOST: 'udp://localhost:8125',
  SERVICE_NAME: 'dannytest',
  METRICS_PREFIX: 'dannytest',
});

agent.metrics.increment('danny.test', 1, []);

// dannytestdanny.test:1|c|#service_name:dannytest
```

```
agent.init(pkg, {
  STATSD_HOST: 'udp://localhost:8125',
  SERVICE_NAME: 'dannytest',
});

agent.metrics.increment('danny.test', 1, []);

// auth0-instrumentation.danny.test:1|c|#service_name:dannytest
```

Metrics prefix can be disabled by providing the env var `METRICS_OMIT_PREFIX`:

```
agent.init(pkg, {
  STATSD_HOST: 'udp://localhost:8125',
  SERVICE_NAME: 'dannytest',
  METRICS_PREFIX: '',
});

agent.metrics.increment('danny.test', 1, []);

// danny.test:1|c|#service_name:dannytest
```

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
