### PR TITLE
Whitelist feature as error tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [3.5.0](https://github.com/auth0/auth0-instrumentation/compare/v3.4.0...v3.5.0) (2020-01-03)
+- Whitelist "feature" to be used as tag in Sentry
+
 # [3.4.0](https://github.com/auth0/auth0-instrumentation/compare/v3.3.0...v3.4.0) (2019-12-11)
 
 

--- a/lib/auth0_sentry_stream.js
+++ b/lib/auth0_sentry_stream.js
@@ -8,7 +8,8 @@ const TAGS_WHITELIST = [
   'log_type',
   'region',
   'environment',
-  'channel'
+  'channel',
+  'feature'
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/instrumentation",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Instrumentation for logs, metrics, and exceptions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Whitelist `feature` as error tag. This is part of the standard schema.